### PR TITLE
Non-uniform Indices support for MPO and variational MPS algorithm; Support Noised two-site vMPS update algorithm

### DIFF
--- a/include/gqmps2/detail/mpogen/fsm.h
+++ b/include/gqmps2/detail/mpogen/fsm.h
@@ -58,7 +58,8 @@ public:
       fsm_site_num_(phys_site_num+1),
       mid_stat_nums_(phys_site_num+1, 0),
       has_readys_(phys_site_num+1, false),
-      has_finals_(phys_site_num+1, false) {
+      has_finals_(phys_site_num+1, false),
+      id_op_labels_(phys_site_num, kIdOpLabel) {
     assert(fsm_site_num_ == phys_site_num_ + 1); 
   }
   
@@ -75,6 +76,8 @@ public:
   SparOpReprMatVec GenMatRepr(void) const;
 
   SparOpReprMatVec GenCompressedMatRepr(void) const;
+
+  void ReplaceIdOpLabels(std::vector<OpLabel> &);
 
 
 private:
@@ -93,6 +96,8 @@ private:
   std::vector<bool> has_readys_;
   std::vector<bool> has_finals_;
   FSMPathVec fsm_paths_;
+
+  std::vector<OpLabel> id_op_labels_;
 };
 
 
@@ -111,9 +116,9 @@ void FSM::AddPath(
   // Set operator representations.
   for (size_t i = 0; i < phys_site_num_; ++i) {
     if (i < head_ntrvl_site_idx) {
-      fsm_path.op_reprs[i] = kIdOpRepr;
+      fsm_path.op_reprs[i] = OpRepr(id_op_labels_[i]);
     } else if (i > tail_ntrvl_site_idx) {
-      fsm_path.op_reprs[i] = kIdOpRepr;
+      fsm_path.op_reprs[i] = OpRepr(id_op_labels_[i]);
     } else {
       fsm_path.op_reprs[i] = ntrvl_ops[i-head_ntrvl_site_idx];
     }
@@ -233,6 +238,12 @@ SparOpReprMatVec FSM::GenCompressedMatRepr(void) const {
     SparOpReprMatRowCompresser(comp_mat_repr[i], comp_mat_repr[i-1]);
   }
   return comp_mat_repr;
+}
+
+
+void FSM::ReplaceIdOpLabels(std::vector<OpLabel> &new_id_op_labels) {
+  assert(new_id_op_labels.size() == id_op_labels_.size());
+  id_op_labels_ = new_id_op_labels;
 }
 
 

--- a/include/gqmps2/detail/mpogen/mpogen_impl.h
+++ b/include/gqmps2/detail/mpogen/mpogen_impl.h
@@ -167,8 +167,8 @@ void MPOGenerator<TenElemType>::AddTerm(
 template <typename TenElemType>
 void MPOGenerator<TenElemType>::AddTerm(
         const TenElemType coef,
-        const GQTensorVec &phys_ops,
-        const std::vector<long> &idxs,
+        GQTensorVec phys_ops,
+        std::vector<long> idxs,
         const GQTensorVec &inst_ops,
         const std::vector<long> &inst_idxs) {
   assert(phys_ops.size() == idxs.size());
@@ -176,6 +176,22 @@ void MPOGenerator<TenElemType>::AddTerm(
   assert((inst_ops.size() == phys_ops.size()-1) ||
          (inst_ops.size() == phys_ops.size()));
   if (coef == TenElemType(0)) { return; }   // If coef is zero, do nothing.
+
+  if (!std::is_sorted(idxs.begin(),idxs.end())){
+    std::map<long, GQTensorT> TmpMap;
+    for (int i=0; i < idxs.size(); i++) {
+      TmpMap[idxs[i]] = phys_ops[i];
+    }
+    typename std::map<long,GQTensorT>::iterator iter;
+    int i = 0;
+    for (iter = TmpMap.begin(); iter!=TmpMap.end();iter++){
+      idxs[i] = iter->first;
+      phys_ops[i] = iter->second;
+      i=i+1;
+    }
+    TmpMap.clear();
+  }
+
   CoefLabel coef_label = coef_label_convertor_.Convert(coef);
   long ntrvl_op_idx_head, ntrvl_op_idx_tail;
   ntrvl_op_idx_head = idxs.front();

--- a/include/gqmps2/detail/mpogen/mpogen_impl.h
+++ b/include/gqmps2/detail/mpogen/mpogen_impl.h
@@ -39,18 +39,55 @@ void AddOpToCentMpoTen(
     const long, const long);
 
 
-// MPO generator
+/** MPOGenerator<TenElemType>::MPOGenerator
+ * For uniform hilbert spaces, i.e. Heisenberg model, Hubbard model, etc.
+ * @tparam TenElemType GQTEN_Double or GQTEN_Complex
+ * @param N system size
+ * @param pb_out local hilbert spaces
+ * @param zero_div the leftmost index of MPO
+ */
 template <typename TenElemType>
 MPOGenerator<TenElemType>::MPOGenerator(
-    const long N, const Index &pb, const QN &zero_div) :
+    const long N, const Index &pb_out, const QN &zero_div) :
     N_(N),
-    pb_out_(pb),
     zero_div_(zero_div),
     fsm_(N) {
-  pb_in_ = InverseIndex(pb_out_);
-  id_op_ = GenIdOpTen_(pb_out_);
+      for(long i = 0; i< N; i++) {
+        pb_out_vector_.push_back(pb_out);
+        pb_in_vector_.push_back(InverseIndex(pb_out));
+        id_op_vector_.push_back(GenIdOpTen_(pb_out));
+      }
+      op_label_convertor_ = LabelConvertor<GQTensorT>(id_op_vector_[0]);
+      coef_label_convertor_ = LabelConvertor<TenElemType>(TenElemType(1));
+}
+
+/** MPOGenerator<TenElemType>::MPOGenerator
+ * For non-uniform hilbert spaces, i.e. phonon-electron coupling, or mixed space DMRG
+ * @tparam TenElemType GQTEN_Double or GQTEN_Complex
+ * @param pb_out_vector local hilbert space sets, pb_out_vector.size() == the system size
+ * @param zero_d the leftmost index of MPO
+ * iv
+ */
+template <typename TenElemType>
+MPOGenerator<TenElemType>::MPOGenerator(
+  const std::vector<Index> &pb_out_vector, const QN &zero_div) :
+  N_(pb_out_vector.size()),
+  pb_out_vector_(pb_out_vector),
+  zero_div_(zero_div),
+  fsm_(pb_out_vector.size()) {
+  for(auto iter = pb_out_vector.begin(); iter < pb_out_vector.end(); iter++) {
+    pb_in_vector_.push_back(InverseIndex(*iter));
+    id_op_vector_.push_back(GenIdOpTen_(*iter));
+  }
+
+  op_label_convertor_ = LabelConvertor<GQTensorT>(id_op_vector_[0]);
+  std::vector<OpLabel> id_op_label_vector;
+  for(auto iter = id_op_vector_.begin(); iter< id_op_vector_.end();iter++){
+    id_op_label_vector.push_back(op_label_convertor_.Convert(*iter));
+  }
+  fsm_.ReplaceIdOpLabels(id_op_label_vector);
+
   coef_label_convertor_ = LabelConvertor<TenElemType>(TenElemType(1));
-  op_label_convertor_ = LabelConvertor<GQTensorT>(id_op_);
 }
 
 
@@ -63,7 +100,15 @@ MPOGenerator<TenElemType>::GenIdOpTen_(const Index &pb_out) {
   return id_op;
 }
 
-
+/** MPOGenerator<TenElemType>::AddTerm
+ * insertion operators fill the among physical operators compactly, usually for uniform cases.
+ * The number of physical operators = 2 or more, but must specify the insertion operators
+ * @tparam TenElemType GQTEN_Double or GQTEN_Complex
+ * @param coef coefficient of physical term
+ * @param phys_ops physical operators
+ * @param idxs site numbers of physical operators
+ * @param inst_ops insertion operator set
+ */
 template <typename TenElemType>
 void MPOGenerator<TenElemType>::AddTerm(
     const TenElemType coef,
@@ -107,22 +152,100 @@ void MPOGenerator<TenElemType>::AddTerm(
   fsm_.AddPath(ntrvl_op_idx_head, ntrvl_op_idx_tail, ntrvl_op_reprs);
 }
 
+
+/** MPOGenerator<TenElemType>::AddTerm
+ * insertion operator sites are specified, can be used for non-uniform cases.
+ * The number of physical operators = 2 or more, but must specify the insertion operators and their positions
+ * @tparam TenElemType GQTEN_Double or GQTEN_Complex
+ * @param coef coefficient
+ * @param phys_ops physical operators
+ * @param idxs corresponding site number of physical operators
+ * @param inst_ops insertion operators, # = (# of idxs) or (# of idxs -1)
+ * @param inst_idxs the number of which sites was inserted, usually for
+ *          the non-uniform hilbert spaces cases.
+ */
+template <typename TenElemType>
+void MPOGenerator<TenElemType>::AddTerm(
+        const TenElemType coef,
+        const GQTensorVec &phys_ops,
+        const std::vector<long> &idxs,
+        const GQTensorVec &inst_ops,
+        const std::vector<long> &inst_idxs) {
+  assert(phys_ops.size() == idxs.size());
+  for (auto idx : idxs) { assert(idx < N_); }
+  assert((inst_ops.size() == phys_ops.size()-1) ||
+         (inst_ops.size() == phys_ops.size()));
+  if (coef == TenElemType(0)) { return; }   // If coef is zero, do nothing.
+  CoefLabel coef_label = coef_label_convertor_.Convert(coef);
+  long ntrvl_op_idx_head, ntrvl_op_idx_tail;
+  ntrvl_op_idx_head = idxs.front();
+  if (inst_ops.size() == phys_ops.size()-1) {
+    ntrvl_op_idx_tail = idxs.back();
+  } else if (inst_ops.size() == phys_ops.size()) {
+    ntrvl_op_idx_tail = N_ - 1;
+  }
+  OpReprVec ntrvl_op_reprs;
+  size_t last_phys_op_idx;
+  for (long i = ntrvl_op_idx_head; i <= ntrvl_op_idx_tail; ++i) {
+    auto poss_it = std::find(idxs.cbegin(), idxs.cend(), i);
+    if (poss_it != idxs.cend()) {
+      auto phys_ops_idx = poss_it - idxs.cbegin();
+      OpLabel op_label = op_label_convertor_.Convert(phys_ops[phys_ops_idx]);
+      if (phys_ops_idx == 0) {
+        ntrvl_op_reprs.push_back(OpRepr(coef_label, op_label));
+      } else {
+        ntrvl_op_reprs.push_back(OpRepr(op_label));
+      }
+      last_phys_op_idx = phys_ops_idx;
+    } else if ((std::find(inst_idxs.cbegin(), inst_idxs.cend(), i) ) != inst_idxs.cend() ) {
+      OpLabel op_label = op_label_convertor_.Convert(
+              inst_ops[last_phys_op_idx]);
+      ntrvl_op_reprs.push_back(OpRepr(op_label));
+    } else {
+      OpLabel op_label = op_label_convertor_.Convert(id_op_vector_[i]);
+      ntrvl_op_reprs.push_back(OpRepr(op_label));
+    }
+  }
+  assert(ntrvl_op_reprs.size() == (ntrvl_op_idx_tail - ntrvl_op_idx_head + 1));
+
+  fsm_.AddPath(ntrvl_op_idx_head, ntrvl_op_idx_tail, ntrvl_op_reprs);
+}
+
+/** MPOGenerator<TenElemType>::AddTerm
+ * used for two cases: 1. @param inst_op are specify, used for 2 or more sites interaction with inst_op filled
+ *                          in all of the sites between the physical operators, usually for uniform lattices.
+ *                     2. @param inst_op are neglected, used for 2 or more sites interaction without inst_op between
+ *                          the physical operators, can be used for uniform/non-uniform lattices.
+ * @tparam TenElemType GQTEN_Double or GQTEN_Complex
+ * @param coef coefficient
+ * @param phys_ops physical operators
+ * @param idxs site number of physical operators
+ * @param inst_op only one operator, the insertion operators between different intervals are the same
+ */
 template <typename TenElemType>
 void MPOGenerator<TenElemType>::AddTerm(
     const TenElemType coef,
     const GQTensorVec &phys_ops,
     const std::vector<long> &idxs,
     const GQTensorT &inst_op) {
-  GQTensorT instop = inst_op;
-  if (instop == kNullOperator<TenElemType>) { instop = id_op_; }
   auto phys_ops_num = phys_ops.size();
   assert(phys_ops_num > 0);
-  GQTensorVec inst_ops(phys_ops_num-1, instop);
-
-  AddTerm(coef, phys_ops, idxs, inst_ops);
+  GQTensorVec inst_ops(phys_ops_num-1, inst_op);
+  if (inst_op != kNullOperator<TenElemType>) {
+    AddTerm(coef, phys_ops, idxs, inst_ops);
+  }else{
+    std::vector<long> inst_idxs_null;
+    AddTerm(coef, phys_ops, idxs, inst_ops,inst_idxs_null);
+  }
 }
 
-
+/** MPOGenerator<TenElemType>::AddTerm
+ * For one site terms, e.g. external field term, Hubbard U term
+ * @tparam TenElemType GQTEN_Double or GQTEN_Complex
+ * @param coef coefficient
+ * @param phys_op physical operator
+ * @param idx site number
+ */
 template <typename TenElemType>
 void MPOGenerator<TenElemType>::AddTerm(
     const TenElemType coef,
@@ -171,7 +294,7 @@ MPOGenerator<TenElemType>::Gen(void) {
                             fsm_comp_mat_repr[i], trans_vb, label_op_mapping);
       mpo[i] = CentMpoTenRepr2MpoTen_(
                    fsm_comp_mat_repr[i], lvb, trans_vb,
-                   label_coef_mapping, label_op_mapping);
+                   label_coef_mapping, label_op_mapping, i);
     }
   }
   return mpo;
@@ -243,7 +366,7 @@ MPOGenerator<TenElemType>::HeadMpoTenRepr2MpoTen_(
     const SparOpReprMat &op_repr_mat,
     const Index &rvb,
     const TenElemVec &label_coef_mapping, const GQTensorVec &label_op_mapping) {
-  auto pmpo_ten = new GQTensorT({pb_in_, rvb, pb_out_});
+  auto pmpo_ten = new GQTensorT({pb_in_vector_.front(), rvb, pb_out_vector_.front()});
   for (size_t y = 0; y < op_repr_mat.cols; ++y) {
     auto elem = op_repr_mat(0, y);
     if (elem != kNullOpRepr) {
@@ -261,7 +384,7 @@ MPOGenerator<TenElemType>::TailMpoTenRepr2MpoTen_(
     const SparOpReprMat &op_repr_mat,
     const Index &lvb,
     const TenElemVec &label_coef_mapping, const GQTensorVec &label_op_mapping) {
-  auto pmpo_ten = new GQTensor<TenElemType>({pb_in_, lvb, pb_out_});
+  auto pmpo_ten = new GQTensor<TenElemType>({pb_in_vector_.back(), lvb, pb_out_vector_.back()});
   for (size_t x = 0; x < op_repr_mat.rows; ++x) {
     auto elem = op_repr_mat(x, 0);
     if (elem != kNullOpRepr) {
@@ -279,8 +402,9 @@ MPOGenerator<TenElemType>::CentMpoTenRepr2MpoTen_(
     const SparOpReprMat &op_repr_mat,
     const Index &lvb,
     const Index &rvb,
-    const TenElemVec &label_coef_mapping, const GQTensorVec &label_op_mapping) {
-  auto pmpo_ten = new GQTensor<TenElemType>({lvb, pb_in_, pb_out_, rvb});
+    const TenElemVec &label_coef_mapping, const GQTensorVec &label_op_mapping,
+    const long site) {
+  auto pmpo_ten = new GQTensor<TenElemType>({lvb, pb_in_vector_[site], pb_out_vector_[site], rvb});
   for (size_t x = 0; x < op_repr_mat.rows; ++x) {
     for (size_t y = 0; y < op_repr_mat.cols; ++y) {
       auto elem = op_repr_mat(x, y);

--- a/include/gqmps2/detail/mpogen/sparse_mat.h
+++ b/include/gqmps2/detail/mpogen/sparse_mat.h
@@ -11,6 +11,7 @@
 
 #include <iostream>
 #include <vector>
+#include "assert.h"
 
 
 template <typename ElemType>

--- a/include/gqmps2/detail/mps_measu_impl.h
+++ b/include/gqmps2/detail/mps_measu_impl.h
@@ -73,8 +73,7 @@ MeasuResElem<TenElemType> MultiSiteOpAvg(
 
 template <typename TenType>
 void CtrctMidTen(
-    const MPS<TenType> &, const long,
-    const TenType &,TenType * &);
+    const MPS<TenType> &, const long, const TenType &,TenType * &);
 
 template <typename TenType>
 void CtrctMidTen(
@@ -242,6 +241,31 @@ MeasuRes<TenElemType> MeasureTwoSiteOp(
     {inst_op});
   std::vector<long> NullVector;
   std::vector<std::vector<long>> insertsite_set(measu_event_num, NullVector);
+  return MeasureMultiSiteOp(
+    mps,
+    phys_ops_set,
+    inst_ops_set,
+    sites_set,
+    insertsite_set,
+    res_file_basename);
+}
+
+template <typename TenElemType>
+MeasuRes<TenElemType> MeasureTwoSiteOp(
+  MPS<GQTensor<TenElemType>> &mps,
+  const std::vector<GQTensor<TenElemType>> &phys_ops,
+  const std::vector<std::vector<long>> &sites_set,
+  const std::vector<std::vector<long>> &insertsite_set,
+  const std::string &res_file_basename) {
+  assert(phys_ops.size() == 2);
+  auto measu_event_num = sites_set.size();
+  std::vector<std::vector<GQTensor<TenElemType>>> phys_ops_set(
+    measu_event_num,
+    phys_ops);
+  auto inst_op = phys_ops.front();
+  std::vector<std::vector<GQTensor<TenElemType>>> inst_ops_set(
+    measu_event_num,
+    {inst_op});
   return MeasureMultiSiteOp(
     mps,
     phys_ops_set,

--- a/include/gqmps2/detail/mps_measu_impl.h
+++ b/include/gqmps2/detail/mps_measu_impl.h
@@ -129,7 +129,7 @@ MeasuRes<TenElemType> MeasureOneSiteOp(
 }
 
 /** MeasuRes<TenElemType> MeasureOneSiteOp
- * To specify which site to be measured
+ * To specify which sites to be measured
  * @tparam TenElemType
  * @param mps
  * @param op
@@ -143,15 +143,19 @@ MeasuRes<TenElemType> MeasureOneSiteOp(
   const std::vector<long> &site_set,
   const std::string &res_file_basename) {
   auto N = mps.N;
-  MeasuRes<TenElemType> measu_res(N);
+  for(auto iter=site_set.begin(); iter<site_set.end();iter++){
+    assert(*iter < N);
+  }
+  MeasuRes<TenElemType> measu_res(site_set.size());
   bool disk_flag =false;
   if(mps.tens[0] == NULL) disk_flag = true;
+  long i =0;
   for (auto iter=site_set.begin(); iter<site_set.end();iter++) {
-    long i = *iter;
-    CentralizeMps(mps, i);
-    if (disk_flag) ReadMps(i,mps.tens);
-    measu_res[i] = OneSiteOpAvg(*mps.tens[i], op, i, N);
-    if (disk_flag) SaveMps(i,mps.tens);
+    CentralizeMps(mps, *iter);
+    if (disk_flag) ReadMps(*iter,mps.tens);
+    measu_res[i] = OneSiteOpAvg(*mps.tens[*iter], op, *iter, N);
+    if (disk_flag) SaveMps(*iter,mps.tens);
+    i++;
   }
   DumpMeasuRes(measu_res, res_file_basename);
   return measu_res;

--- a/include/gqmps2/detail/mps_measu_impl.h
+++ b/include/gqmps2/detail/mps_measu_impl.h
@@ -19,38 +19,69 @@ using namespace gqten;
 
 
 // Forward declaration.
+template <typename TenType>
+void ReadMps(const int i, std::vector<TenType *> & mps);
+template <typename TenType>
+void SaveMps(const int i, std::vector<TenType *> & mps);
+
+
+///Below two functions are added by wanghx 25 June 2020, note don't conflict in the future.
+template <typename TenType>
+void ReadMps(const int i, std::vector<TenType *> & mps){
+  assert(mps[i]==NULL);
+  mps[i] = new TenType();
+  std::string file;
+  file = kMpsPath + "/" + kMpsTenBaseName + std::to_string(i) + "." + kGQTenFileSuffix;
+  std::ifstream ifs(file, std::ifstream::binary);
+  bfread(ifs, *mps[i]);
+  ifs.close();
+  return;
+}
+template <typename TenType>
+void SaveMps(const int i, std::vector<TenType *> & mps){
+  std::string file;
+  file = kMpsPath + "/" + kMpsTenBaseName + std::to_string(i) + "." + kGQTenFileSuffix;
+  std::ofstream ofs(file, std::ifstream::binary);
+  bfwrite(ofs, *mps[i]);
+  ofs.close();
+  delete mps[i];
+  mps[i] = NULL;
+  return;
+}
+
 template <typename TenElemType>
 MeasuResElem<TenElemType> OneSiteOpAvg(
-    const GQTensor<TenElemType> &, const GQTensor<TenElemType> &,
-    const long, const long);
+  const GQTensor<TenElemType> &, // mps tensor
+  const GQTensor<TenElemType> &, // operator being measured
+  const long, //site number of the operator
+  const long);// total system size
 
 template <typename TenElemType>
 MeasuResElem<TenElemType> MultiSiteOpAvg(
     MPS<GQTensor<TenElemType>> &,
     const std::vector<GQTensor<TenElemType>> &,
     const std::vector<GQTensor<TenElemType>> &,
-    const GQTensor<TenElemType> &,
     const std::vector<long> &);
+
+template <typename TenElemType>
+MeasuResElem<TenElemType> MultiSiteOpAvg(
+  MPS<GQTensor<TenElemType>> &,
+  const std::vector<GQTensor<TenElemType>> &,
+  const std::vector<GQTensor<TenElemType>> &,
+  const std::vector<long> &,
+  const std::vector<long> &);
 
 template <typename TenType>
 void CtrctMidTen(
     const MPS<TenType> &, const long,
-    const TenType &, const TenType &,
-    TenType * &);
+    const TenType &,TenType * &);
 
+template <typename TenType>
+void CtrctMidTen(
+  const MPS<TenType> &mps, const long site, TenType * &t);
 template <typename AvgType>
 void DumpMeasuRes(const MeasuRes<AvgType> &, const std::string &);
 
-
-// Helpers.
-inline bool IsOrderKept(const std::vector<long> &sites) {
-  auto ordered_sites = sites;
-  std::sort(ordered_sites.begin(), ordered_sites.end());
-  for (std::size_t i = 0; i < sites.size(); ++i) {
-    if (sites[i] != ordered_sites[i]) { return false; }
-  }
-  return true;
-}
 
 
 inline void DumpSites(std::ofstream &ofs, const std::vector<long> &sites) {
@@ -77,22 +108,56 @@ inline void DumpAvgVal(std::ofstream &ofs, const GQTEN_Complex avg) {
 }
 
 
-// Measure one-site operator.
+/// Measure one-site operator.
+/// Modified by wanghx 25 June 2020, to add support for disk operation.
 template <typename TenElemType>
 MeasuRes<TenElemType> MeasureOneSiteOp(
     MPS<GQTensor<TenElemType>> &mps,
     const GQTensor<TenElemType> &op, const std::string &res_file_basename) {
   auto N = mps.N;
   MeasuRes<TenElemType> measu_res(N);
+  bool disk_flag =false;
+  if(mps.tens[0] == NULL) disk_flag = true;
   for (std::size_t i = 0; i < N; ++i) {
     CentralizeMps(mps, i);
+    if (disk_flag) ReadMps(i,mps.tens);
     measu_res[i] = OneSiteOpAvg(*mps.tens[i], op, i, N);
+    if (disk_flag) SaveMps(i,mps.tens);
   }
   DumpMeasuRes(measu_res, res_file_basename);
   return measu_res;
 }
 
+/** MeasuRes<TenElemType> MeasureOneSiteOp
+ * To specify which site to be measured
+ * @tparam TenElemType
+ * @param mps
+ * @param op
+ * @param res_file_basename
+ * @return
+ */
+template <typename TenElemType>
+MeasuRes<TenElemType> MeasureOneSiteOp(
+  MPS<GQTensor<TenElemType>> &mps,
+  const GQTensor<TenElemType> &op,
+  const std::vector<long> &site_set,
+  const std::string &res_file_basename) {
+  auto N = mps.N;
+  MeasuRes<TenElemType> measu_res(N);
+  bool disk_flag =false;
+  if(mps.tens[0] == NULL) disk_flag = true;
+  for (auto iter=site_set.begin(); iter<site_set.end();iter++) {
+    long i = *iter;
+    CentralizeMps(mps, i);
+    if (disk_flag) ReadMps(i,mps.tens);
+    measu_res[i] = OneSiteOpAvg(*mps.tens[i], op, i, N);
+    if (disk_flag) SaveMps(i,mps.tens);
+  }
+  DumpMeasuRes(measu_res, res_file_basename);
+  return measu_res;
+}
 
+/// Modified by wanghx 25 June 2020, to add support for disk operation.
 template <typename TenElemType>
 MeasuResSet<TenElemType> MeasureOneSiteOp(
     MPS<GQTensor<TenElemType>> &mps,
@@ -101,15 +166,19 @@ MeasuResSet<TenElemType> MeasureOneSiteOp(
   auto op_num = ops.size();
   assert(op_num == res_file_basenames.size());
   auto N = mps.N;
+  bool disk_flag =false;
+  if(mps.tens[0] == NULL) disk_flag = true;
   MeasuResSet<TenElemType> measu_res_set(op_num);
   for (auto &measu_res : measu_res_set) {
     measu_res = MeasuRes<TenElemType>(N);
   }
   for (std::size_t i = 0; i < N; ++i) {
     CentralizeMps(mps, i);
+    if (disk_flag) ReadMps(i,mps.tens);
     for (std::size_t j = 0; j < op_num; ++j) {
       measu_res_set[j][i] = OneSiteOpAvg(*mps.tens[i], ops[j], i, N);
     }
+    if (disk_flag) SaveMps(i,mps.tens);
   }
   for (std::size_t i = 0; i < op_num; ++i) {
     DumpMeasuRes(measu_res_set[i], res_file_basenames[i]);
@@ -124,7 +193,6 @@ MeasuRes<TenElemType> MeasureTwoSiteOp(
     MPS<GQTensor<TenElemType>> &mps,
     const std::vector<GQTensor<TenElemType>> &phys_ops,
     const GQTensor<TenElemType> &inst_op,
-    const GQTensor<TenElemType> &id_op,
     const std::vector<std::vector<long>> &sites_set,
     const std::string &res_file_basename) {
   assert(phys_ops.size() == 2);
@@ -139,9 +207,44 @@ MeasuRes<TenElemType> MeasureTwoSiteOp(
              mps,
              phys_ops_set,
              inst_ops_set,
-             id_op,
              sites_set,
              res_file_basename);
+}
+
+
+/** MeasuRes<TenElemType> MeasureTwoSiteOp
+ * No insertion operators
+ * @tparam TenElemType
+ * @param mps
+ * @param phys_ops
+ * @param sites_set
+ * @param res_file_basename
+ * @return
+ */
+template <typename TenElemType>
+MeasuRes<TenElemType> MeasureTwoSiteOp(
+  MPS<GQTensor<TenElemType>> &mps,
+  const std::vector<GQTensor<TenElemType>> &phys_ops,
+  const std::vector<std::vector<long>> &sites_set,
+  const std::string &res_file_basename) {
+  assert(phys_ops.size() == 2);
+  auto measu_event_num = sites_set.size();
+  std::vector<std::vector<GQTensor<TenElemType>>> phys_ops_set(
+    measu_event_num,
+    phys_ops);
+  auto inst_op = phys_ops.front();
+  std::vector<std::vector<GQTensor<TenElemType>>> inst_ops_set(
+    measu_event_num,
+    {inst_op});
+  std::vector<long> NullVector;
+  std::vector<std::vector<long>> insertsite_set(measu_event_num, NullVector);
+  return MeasureMultiSiteOp(
+    mps,
+    phys_ops_set,
+    inst_ops_set,
+    sites_set,
+    insertsite_set,
+    res_file_basename);
 }
 
 
@@ -151,7 +254,6 @@ MeasuRes<TenElemType> MeasureMultiSiteOp(
     MPS<GQTensor<TenElemType>> &mps,
     const std::vector<std::vector<GQTensor<TenElemType>>> &phys_ops_set,
     const std::vector<std::vector<GQTensor<TenElemType>>> &inst_ops_set,
-    const GQTensor<TenElemType> &id_op,
     const std::vector<std::vector<long>> &sites_set,
     const std::string &res_file_basename) {
   auto measu_event_num = sites_set.size();
@@ -161,9 +263,45 @@ MeasuRes<TenElemType> MeasureMultiSiteOp(
     auto &inst_ops = inst_ops_set[i];
     auto &sites = sites_set[i];
     assert(sites.size() > 1);
-    assert(IsOrderKept(sites));
+    assert(std::is_sorted(sites.begin(),sites.end()));
     CentralizeMps(mps, sites[0]);
-    measu_res[i] = MultiSiteOpAvg(mps, phys_ops, inst_ops, id_op, sites);
+    measu_res[i] = MultiSiteOpAvg(mps, phys_ops, inst_ops, sites);
+  }
+  DumpMeasuRes(measu_res, res_file_basename);
+  return measu_res;
+}
+
+
+/** MeasuRes<TenElemType> MeasureMultiSiteOp
+ * Specify which sites are inserted
+ * @tparam TenElemType
+ * @param mps
+ * @param phys_ops_set
+ * @param inst_ops_set
+ * @param sites_set
+ * @param insertsites_set
+ * @param res_file_basename
+ * @return
+ */
+template <typename TenElemType>
+MeasuRes<TenElemType> MeasureMultiSiteOp(
+  MPS<GQTensor<TenElemType>> &mps,
+  const std::vector<std::vector<GQTensor<TenElemType>>> &phys_ops_set,
+  const std::vector<std::vector<GQTensor<TenElemType>>> &inst_ops_set,
+  const std::vector<std::vector<long>> &sites_set,
+  const std::vector<std::vector<long>> &insertsites_set,
+  const std::string &res_file_basename) {
+  auto measu_event_num = sites_set.size();
+  MeasuRes<TenElemType> measu_res(measu_event_num);
+  for (std::size_t i = 0; i < measu_event_num; ++i) {
+    auto &phys_ops = phys_ops_set[i];
+    auto &inst_ops = inst_ops_set[i];
+    auto &sites = sites_set[i];
+    auto &insert_sites=insertsites_set[i];
+    assert(sites.size() > 1);
+    assert(std::is_sorted(sites.begin(),sites.end()));
+    CentralizeMps(mps, sites[0]);
+    measu_res[i] = MultiSiteOpAvg(mps, phys_ops, inst_ops, sites, insert_sites);
   }
   DumpMeasuRes(measu_res, res_file_basename);
   return measu_res;
@@ -203,19 +341,27 @@ MeasuResElem<TenElemType> OneSiteOpAvg(
   return MeasuResElem<TenElemType>({site}, avg);
 }
 
-
+/** MeasuResElem<TenElemType> MultiSiteOpAvg
+ * Add by wanghx 25 June 2020.Difference with previous version: No identity parameter;
+ * And mps can be saved into disk
+ * @tparam TenElemType
+ * @param mps
+ * @param phys_ops
+ * @param inst_ops
+ * @param sites on which sites physical operators are acting
+ * @return
+ */
 template <typename TenElemType>
 MeasuResElem<TenElemType> MultiSiteOpAvg(
-    MPS<GQTensor<TenElemType>> &mps,
-    const std::vector<GQTensor<TenElemType>> &phys_ops,
-    const std::vector<GQTensor<TenElemType>> &inst_ops,
-    const GQTensor<TenElemType> &id_op,
-    const std::vector<long> &sites) {
+  MPS<GQTensor<TenElemType>> &mps,
+  const std::vector<GQTensor<TenElemType>> &phys_ops,
+  const std::vector<GQTensor<TenElemType>> &inst_ops,
+  const std::vector<long> &sites) {
   // Deal with head tensor.
   std::vector<long> head_mps_ten_ctrct_axes1;
   std::vector<long> head_mps_ten_ctrct_axes2;
   std::vector<long> head_mps_ten_ctrct_axes3;
-  if (sites[0] == 0) {
+  if (sites[0] == 0) { // MPS have left canonical form to sites[0]
     head_mps_ten_ctrct_axes1 = {0};
     head_mps_ten_ctrct_axes2 = {1};
     head_mps_ten_ctrct_axes3 = {0};
@@ -224,12 +370,18 @@ MeasuResElem<TenElemType> MultiSiteOpAvg(
     head_mps_ten_ctrct_axes2 = {0, 2};
     head_mps_ten_ctrct_axes3 = {0, 1};
   }
+  bool disk_save_flag = false;
+  if (mps.tens[0] == NULL){// if point to nothing, using the read-saving disk mode
+    ReadMps(sites[0], mps.tens);
+    disk_save_flag = true;
+  }
   auto temp_ten0 = Contract(
-                       *mps.tens[sites[0]], phys_ops[0],
-                       {head_mps_ten_ctrct_axes1, {0}});
+    *mps.tens[sites[0]], phys_ops[0],
+    {head_mps_ten_ctrct_axes1, {0}});
   auto temp_ten = Contract(
-                       *temp_ten0, Dag(*mps.tens[sites[0]]),
-                       {head_mps_ten_ctrct_axes2, head_mps_ten_ctrct_axes3});
+    *temp_ten0, Dag(*mps.tens[sites[0]]),
+    {head_mps_ten_ctrct_axes2, head_mps_ten_ctrct_axes3});
+  if(disk_save_flag) SaveMps(sites[0], mps.tens);
   delete temp_ten0;
 
   // Deal with middle tensors.
@@ -238,10 +390,10 @@ MeasuResElem<TenElemType> MultiSiteOpAvg(
   assert(phys_op_num == (inst_op_num+1));
   for (std::size_t i = 0; i < inst_op_num; ++i) {
     for (long j = sites[i]+1; j < sites[i+1]; j++) {
-      CtrctMidTen(mps, j, inst_ops[i], id_op, temp_ten);
-    } 
+      CtrctMidTen(mps, j, inst_ops[i], temp_ten);
+    }
     if (i != inst_op_num-1) {
-      CtrctMidTen(mps, sites[i+1], phys_ops[i+1], id_op, temp_ten); 
+      CtrctMidTen(mps, sites[i+1], phys_ops[i+1], temp_ten);
     }
   }
 
@@ -249,33 +401,130 @@ MeasuResElem<TenElemType> MultiSiteOpAvg(
   std::vector<long> tail_mps_ten_ctrct_axes1;
   std::vector<long> tail_mps_ten_ctrct_axes2;
   if (sites.back() == mps.N-1) {
-    tail_mps_ten_ctrct_axes1 = {0, 1}; 
+    tail_mps_ten_ctrct_axes1 = {0, 1};
     tail_mps_ten_ctrct_axes2 = {1, 0};
   } else {
     tail_mps_ten_ctrct_axes1 = {0, 1, 2};
     tail_mps_ten_ctrct_axes2 = {2, 0, 1};
   }
+  if(disk_save_flag) ReadMps(sites[inst_op_num], mps.tens);
   auto temp_ten2 = Contract(
-                       *mps.tens[sites[inst_op_num]], *temp_ten, 
-                       {{0}, {0}});
+    *mps.tens[sites[inst_op_num]], *temp_ten,
+    {{0}, {0}});
   delete temp_ten;
   auto temp_ten3 = Contract(*temp_ten2, phys_ops[phys_op_num-1], {{0}, {0}});
   delete temp_ten2;
-  auto res_ten = Contract(
-                     *temp_ten3, Dag(*mps.tens[sites[phys_op_num-1]]),
-                     {tail_mps_ten_ctrct_axes1, tail_mps_ten_ctrct_axes2});
+  auto res_ten = Contract(// I think below phys_op_num-1 == inst_op_num? wanghx June 25 2020
+    *temp_ten3, Dag(*mps.tens[sites[phys_op_num-1]]),
+    {tail_mps_ten_ctrct_axes1, tail_mps_ten_ctrct_axes2});
+  if(disk_save_flag) SaveMps(sites[inst_op_num], mps.tens);
   delete temp_ten3;
   auto avg = res_ten->scalar;
   delete res_ten;
   return MeasuResElem<TenElemType>(sites, avg);
 }
 
+/** MeasuResElem<TenElemType> MultiSiteOpAvg
+ * Add by wanghx 30 June 2020. Can specify which sites are inserted. And mps can be saved into disk
+ * @tparam TenElemType GQTEN_Double or GQTEN_Complex
+ * @param mps MPS struct, including mps tensor pointers, center and mps size
+ * @param phys_ops physical operators, a vector
+ * @param inst_ops insertion operators, a vector
+ * @param phys_sites on which sites physical operators are acting
+ * @param inst_sites on which sites insertion operators are inserted
+ * @return Measure's results
+ */
+template <typename TenElemType>
+MeasuResElem<TenElemType> MultiSiteOpAvg(
+  MPS<GQTensor<TenElemType>> &mps,
+  const std::vector<GQTensor<TenElemType>> &phys_ops,
+  const std::vector<GQTensor<TenElemType>> &inst_ops,
+  const std::vector<long> &phys_sites,
+  const std::vector<long> &inst_sites) {
+  // Deal with head tensor.
+  std::vector<long> head_mps_ten_ctrct_axes1;
+  std::vector<long> head_mps_ten_ctrct_axes2;
+  std::vector<long> head_mps_ten_ctrct_axes3;
+  if (phys_sites[0] == 0) { // MPS have left canonical form to  phys_sites[0]
+    head_mps_ten_ctrct_axes1 = {0};
+    head_mps_ten_ctrct_axes2 = {1};
+    head_mps_ten_ctrct_axes3 = {0};
+  } else {
+    head_mps_ten_ctrct_axes1 = {1};
+    head_mps_ten_ctrct_axes2 = {0, 2};
+    head_mps_ten_ctrct_axes3 = {0, 1};
+  }
+  bool disk_save_flag = false;
+  if (mps.tens[0] == NULL){// if point to nothing, using the read-saving disk mode
+    ReadMps(phys_sites[0], mps.tens);
+    disk_save_flag = true;
+  }
+  auto temp_ten0 = Contract(
+    *mps.tens[phys_sites[0]], phys_ops[0],
+    {head_mps_ten_ctrct_axes1, {0}});
+  auto temp_ten = Contract(
+    *temp_ten0, Dag(*mps.tens[phys_sites[0]]),
+    {head_mps_ten_ctrct_axes2, head_mps_ten_ctrct_axes3});
+  if(disk_save_flag) SaveMps(phys_sites[0], mps.tens);
+  delete temp_ten0;
 
+  // Deal with middle tensors.
+  auto inst_op_num = inst_ops.size();
+  auto phys_op_num = phys_ops.size();
+  assert(phys_op_num == (inst_op_num+1));
+  for (std::size_t i = 0; i < inst_op_num; ++i) {
+    for (long j = phys_sites[i]+1; j < phys_sites[i+1]; j++) {
+      if(std::find(inst_sites.begin(), inst_sites.end(),j) != inst_sites.end())
+        CtrctMidTen(mps, j, inst_ops[i], temp_ten);
+      else CtrctMidTen(mps, j, temp_ten);
+    }
+    if (i != inst_op_num-1) {
+      CtrctMidTen(mps, phys_sites[i+1], phys_ops[i+1], temp_ten);
+    }
+  }
+
+  // Deal with tail tensor.
+  std::vector<long> tail_mps_ten_ctrct_axes1;
+  std::vector<long> tail_mps_ten_ctrct_axes2;
+  if (phys_sites.back() == mps.N-1) {
+    tail_mps_ten_ctrct_axes1 = {0, 1};
+    tail_mps_ten_ctrct_axes2 = {1, 0};
+  } else {
+    tail_mps_ten_ctrct_axes1 = {0, 1, 2};
+    tail_mps_ten_ctrct_axes2 = {2, 0, 1};
+  }
+  if(disk_save_flag) ReadMps(phys_sites[inst_op_num], mps.tens);
+  auto temp_ten2 = Contract(
+    *mps.tens[phys_sites[inst_op_num]], *temp_ten,
+    {{0}, {0}});
+  delete temp_ten;
+  auto temp_ten3 = Contract(*temp_ten2, phys_ops[phys_op_num-1], {{0}, {0}});
+  delete temp_ten2;
+  auto res_ten = Contract(// I think below phys_op_num-1 == inst_op_num? wanghx June 25 2020
+    *temp_ten3, Dag(*mps.tens[phys_sites[phys_op_num-1]]),
+    {tail_mps_ten_ctrct_axes1, tail_mps_ten_ctrct_axes2});
+  if(disk_save_flag) SaveMps(phys_sites[inst_op_num], mps.tens);
+  delete temp_ten3;
+  auto avg = res_ten->scalar;
+  delete res_ten;
+  return MeasuResElem<TenElemType>(phys_sites, avg);
+}
+
+
+/// Modified by hxwang June 27, 2020, to support non-uniform lattice.
 template <typename TenType>
 void CtrctMidTen(
-    const MPS<TenType> &mps, const long site,
-    const TenType &op, const TenType &id_op,
-    TenType * &t) {
+  const MPS<TenType> &mps, const long site,
+  const TenType &op, TenType * &t) {
+  auto id_op = TenType({op.indexes[0],op.indexes[1]});
+  for(int i = 0;i<id_op.shape[0];i++){
+    id_op({i,i})=1.0;
+  }
+  bool disk_save_flag = false;
+  if (mps.tens[0] == NULL){// if point to nothing, using the read-saving disk mode
+    ReadMps(site, mps.tens);
+    disk_save_flag = true;
+  }
   if (op == id_op) {
     auto temp_ten = Contract(*mps.tens[site], *t, {{0}, {0}});
     delete t;
@@ -289,8 +538,30 @@ void CtrctMidTen(
     t = Contract(*temp_ten2, Dag(*mps.tens[site]), {{1, 2}, {0, 1}});
     delete temp_ten2;
   }
+  if (disk_save_flag) SaveMps(site, mps.tens);
 }
 
+/** void CtrctMidTen
+ * No &op parameter, we suppose it equals identity.
+ * @tparam TenType
+ * @param mps
+ * @param site
+ * @param t
+ */
+template <typename TenType>
+void CtrctMidTen(
+  const MPS<TenType> &mps, const long site, TenType * &t) {
+  bool disk_save_flag = false;
+  if (mps.tens[0] == NULL){// if point to nothing, using the read-saving disk mode
+    ReadMps(site, mps.tens);
+    disk_save_flag = true;
+  }
+  auto temp_ten = Contract(*mps.tens[site], *t, {{0}, {0}});
+  delete t;
+  t = Contract(*temp_ten, Dag(*mps.tens[site]), {{0, 2}, {1, 0}});
+  delete temp_ten;
+  if (disk_save_flag) SaveMps(site, mps.tens);
+}
 
 // Date dump.
 template <typename AvgType>

--- a/include/gqmps2/detail/mps_ops_impl.h
+++ b/include/gqmps2/detail/mps_ops_impl.h
@@ -21,6 +21,10 @@
 namespace  gqmps2 {
 using  namespace gqten;
 
+template <typename TenType>
+void ReadMps(const int i, std::vector<TenType *> & mps);
+template <typename TenType>
+void SaveMps(const int i, std::vector<TenType *> & mps);
 
 // Forward declarations
 // For random initialize MPS operation.
@@ -138,6 +142,63 @@ void RandomInitMps(
   mps[N/2]->Random(zero_div);
   assert(Div(*mps[N/2]) == zero_div);
 }
+
+
+/** Random initialization of MPS, usually for non-uniform cases
+ *
+ * @tparam TenType a realization of template class GQTensor
+ * @param mps a vector storing a series of pointers which point to mps tensors
+ * @param pb_vector physical bond Indices with good quantum numbers, size == system size
+ * @param tot_div total quantum number, the right size quantum number
+ * @param zero_div left side quantum number of mps
+ * @param dmax bond dimension
+ */
+template <typename TenType>
+void RandomInitMps(
+  std::vector<TenType *> &mps,
+  const std::vector<Index> &pb_vector,
+  const QN &tot_div,
+  const QN &zero_div,
+  const long dmax) {
+  MpsFree(mps);
+  Index lvb, rvb;
+
+  assert(pb_vector.size()==mps.size());
+  // Left to center.
+  rvb = GenHeadRightVirtBond(pb_vector.front(), tot_div, dmax);
+  mps[0] = new TenType({pb_vector.front(), rvb});
+  mps[0]->Random(tot_div);
+  assert(Div(*mps[0]) == tot_div);
+  auto N = mps.size();
+  for (std::size_t i = 1; i < N/2; ++i) {
+    lvb = InverseIndex(rvb);
+    rvb = GenBodyRightVirtBond(lvb, pb_vector[i], zero_div, dmax);
+    mps[i] = new TenType({lvb, pb_vector[i], rvb});
+    mps[i]->Random(zero_div);
+    assert(Div(*mps[i]) == zero_div);
+  }
+  auto cent_bond = rvb;
+
+  // Right to center.
+  lvb = GenTailLeftVirtBond(pb_vector.back(), zero_div, dmax);
+  mps[N-1] = new TenType({lvb, pb_vector.back()});
+  mps[N-1]->Random(zero_div);
+  assert(Div(*mps[N-1]) == zero_div);
+  for (std::size_t i = N-2; i > N/2; --i) {
+    rvb = InverseIndex(lvb);
+    lvb = GenBodyLeftVirtBond(rvb, pb_vector[i], zero_div, dmax);
+    mps[i] = new TenType({lvb, pb_vector[i], rvb});
+    mps[i]->Random(zero_div);
+    assert(Div(*mps[i]) == zero_div);
+  }
+
+  rvb = InverseIndex(lvb);
+  lvb = InverseIndex(cent_bond);
+  mps[N/2] = new TenType({lvb, pb_vector[N/2], rvb});
+  mps[N/2]->Random(zero_div);
+  assert(Div(*mps[N/2]) == zero_div);
+}
+
 
 
 inline Index GenHeadRightVirtBond(
@@ -293,6 +354,56 @@ void DirectStateInitMps(
   (*mps[N-1])({0, stat_lab}) = 1;
 }
 
+/** Initialize MPS from a series of integer numbers,  for the non-uniform hilbert space cases
+ *
+ * @tparam TenType A realization of tensor class, GQTensor<GQTEN_Double> or GQTensor<GQTEN_Complex>
+ * @param mps vectors contain the N pointers which point to TenType object, N is the system size
+ * @param stat_labs label the local hilbert space states in order, with size N
+ * @param pb_out_vector label the local hilbert space (physical bond) in order, with size N
+ * @param zero_div left start quantum number
+ */
+template <typename TenType>
+void DirectStateInitMps(
+        std::vector<TenType *> &mps, const std::vector<long> &stat_labs,
+        const std::vector<Index> &pb_out_vector, const QN &zero_div) {
+  auto N = mps.size();
+  assert(N == stat_labs.size());
+  assert(N == pb_out_vector.size());
+  MpsFree(mps);
+  Index lvb, rvb;
+
+  // Calculate total quantum number.
+  auto div = pb_out_vector.front().CoorInterOffsetAndQnsct(stat_labs[0]).qnsct.qn;
+  for (std::size_t i = 1; i < N; ++i) {
+    div += pb_out_vector[i].CoorInterOffsetAndQnsct(stat_labs[i]).qnsct.qn;
+  }
+
+  auto stat_lab = stat_labs[0];
+  auto rvb_qn = div - pb_out_vector.front().CoorInterOffsetAndQnsct(stat_lab).qnsct.qn;
+  rvb = Index({QNSector(rvb_qn, 1)}, OUT);
+  mps[0] = new TenType({pb_out_vector.front(), rvb});
+  (*mps[0])({stat_lab, 0}) = 1;
+
+  for (std::size_t i = 1; i < N-1; ++i) {
+    lvb = InverseIndex(rvb);
+    stat_lab = stat_labs[i];
+    rvb_qn = zero_div -
+             pb_out_vector[i].CoorInterOffsetAndQnsct(stat_lab).qnsct.qn +
+             lvb.CoorInterOffsetAndQnsct(0).qnsct.qn;
+    rvb = Index({QNSector(rvb_qn, 1)}, OUT);
+    mps[i] = new TenType({lvb, pb_out_vector[i], rvb});
+    (*mps[i])({0, stat_lab, 0}) = 1;
+  }
+
+  lvb = InverseIndex(rvb);
+  mps[N-1] = new TenType({lvb, pb_out_vector.back()});
+  stat_lab = stat_labs[N-1];
+  (*mps[N-1])({0, stat_lab}) = 1;
+}
+
+
+
+
 
 template <typename TenType>
 void ExtendDirectRandomInitMps(
@@ -350,6 +461,76 @@ void ExtendDirectRandomInitMps(
 }
 
 
+/** ExtendDirectRandomInitMps
+ *  Initialize MPS as a sum of some direct product states, for non-universal hilbert spaces.
+ * @tparam TenType GQTensor<GQTEN_Double> or GQTensor<GQTEN_Complex>
+ * @param mps A vector store the pointers pointing to GQTensors, but they must point to NULL
+ * @param stat_labs_set A generalization of @param stat_labs in function DirectStateInitMps
+ * @param pb_vector hilbert spaces set
+ * @param zero_div the leftmost U1 quantum number
+ * @param enlarged_dim stat_labs_set.size()
+ */
+template <typename TenType>
+void ExtendDirectRandomInitMps(
+  std::vector<TenType *> &mps,
+  const std::vector<std::vector<long>> &stat_labs_set,
+  const std::vector<Index> &pb_vector, const QN &zero_div, const long enlarged_dim) {
+  auto fusion_stats_num = stat_labs_set.size();
+  assert(fusion_stats_num >= 1);
+  auto N = mps.size();
+  assert(N == stat_labs_set[0].size());
+  Index lvb, rvb;
+  std::vector<QNSector> rvb_qnscts;
+
+  // Calculate total quantum number.
+  auto pb = pb_vector.front();
+  auto div = pb.CoorInterOffsetAndQnsct(stat_labs_set[0][0]).qnsct.qn;
+  for (std::size_t i = 1; i < N; ++i) {
+    div += pb_vector[i].CoorInterOffsetAndQnsct(stat_labs_set[0][i]).qnsct.qn;
+  }
+
+  // Deal with MPS head local tensor.
+  for (std::size_t i = 0; i < fusion_stats_num; ++i) {
+    auto stat_lab = stat_labs_set[i][0];
+    auto rvb_qn = div - pb.CoorInterOffsetAndQnsct(stat_lab).qnsct.qn;
+    rvb_qnscts.push_back(QNSector(rvb_qn, enlarged_dim));
+  }
+  rvb = Index(rvb_qnscts, OUT);
+  rvb_qnscts.clear();
+  mps[0] = new TenType({pb, rvb});
+  mps[0]->Random(div);
+
+  // Deal with MPS middle local tensors.
+  for (std::size_t i = 1; i < N-1; ++i) {
+    auto pb = pb_vector[i];
+    lvb = InverseIndex(rvb);
+    for (std::size_t j = 0; j < fusion_stats_num; ++j) {
+      auto stat_lab = stat_labs_set[j][i];
+      auto rvb_qn = zero_div -
+                    pb.CoorInterOffsetAndQnsct(stat_lab).qnsct.qn +
+                    lvb.CoorInterOffsetAndQnsct(j*enlarged_dim).qnsct.qn;
+      rvb_qnscts.push_back(QNSector(rvb_qn, enlarged_dim));
+    }
+    rvb = Index(rvb_qnscts, OUT);
+    mps[i] = new TenType({lvb, pb, rvb});
+    rvb_qnscts.clear();
+    mps[i]->Random(zero_div);
+  }
+
+  // Deal with MPS tail local tensor.
+  lvb = InverseIndex(rvb);
+  mps[N-1] = new TenType({lvb, pb_vector.back()});
+  mps[N-1]->Random(zero_div);
+
+  // Centralize MPS.
+  auto temp_mps = MPS<TenType>(mps, -1);
+  RightNormalizeMps(temp_mps, temp_mps.N-1, 1);
+}
+
+
+
+
+
 // MPS centralization.
 template <typename MpsType>
 void CentralizeMps(MpsType &mps, const long target_center) {
@@ -374,18 +555,34 @@ void CentralizeMps(MpsType &mps, const long target_center) {
 template <typename MpsType>
 void LeftNormalizeMps(MpsType &mps, const long from, const long to) {
   assert(to >= from);
-  for (long i = from; i <= to; ++i) {
-    LeftNormalizeMpsTen(mps, i);
+  bool disk_flag = false; // Add by wanghx June 25, 2020
+  if (mps.tens.front() == NULL ){
+    disk_flag =true;
+    ReadMps(from, mps.tens);
   }
+  for (long i = from; i <= to; ++i) {
+    if(disk_flag) ReadMps(i+1, mps.tens);
+    LeftNormalizeMpsTen(mps, i);
+    if(disk_flag) SaveMps(i, mps.tens);
+  }
+  if(disk_flag) SaveMps(to+1, mps.tens);
 }
 
 
 template <typename MpsType>
 void RightNormalizeMps(MpsType &mps, const long from, const long to) {
   assert(to <= from);
-  for (long i = from; i >= to; --i) {
-    RightNormalizeMpsTen(mps, i);
+  bool disk_flag = false; // Add by wanghx June 25, 2020
+  if (mps.tens.front() == NULL ){
+    disk_flag =true;
+    ReadMps(from, mps.tens);
   }
+  for (long i = from; i >= to; --i) {
+    if(disk_flag) ReadMps(i-1, mps.tens);
+    RightNormalizeMpsTen(mps, i);
+    if(disk_flag) SaveMps(i, mps.tens);
+  }
+  if(disk_flag) SaveMps(to-1, mps.tens);
 }
 
 

--- a/include/gqmps2/detail/mps_ops_impl.h
+++ b/include/gqmps2/detail/mps_ops_impl.h
@@ -21,10 +21,6 @@
 namespace  gqmps2 {
 using  namespace gqten;
 
-template <typename TenType>
-void ReadMps(const int i, std::vector<TenType *> & mps);
-template <typename TenType>
-void SaveMps(const int i, std::vector<TenType *> & mps);
 
 // Forward declarations
 // For random initialize MPS operation.
@@ -555,34 +551,18 @@ void CentralizeMps(MpsType &mps, const long target_center) {
 template <typename MpsType>
 void LeftNormalizeMps(MpsType &mps, const long from, const long to) {
   assert(to >= from);
-  bool disk_flag = false; // Add by wanghx June 25, 2020
-  if (mps.tens.front() == NULL ){
-    disk_flag =true;
-    ReadMps(from, mps.tens);
-  }
   for (long i = from; i <= to; ++i) {
-    if(disk_flag) ReadMps(i+1, mps.tens);
     LeftNormalizeMpsTen(mps, i);
-    if(disk_flag) SaveMps(i, mps.tens);
   }
-  if(disk_flag) SaveMps(to+1, mps.tens);
 }
 
 
 template <typename MpsType>
 void RightNormalizeMps(MpsType &mps, const long from, const long to) {
   assert(to <= from);
-  bool disk_flag = false; // Add by wanghx June 25, 2020
-  if (mps.tens.front() == NULL ){
-    disk_flag =true;
-    ReadMps(from, mps.tens);
-  }
   for (long i = from; i >= to; --i) {
-    if(disk_flag) ReadMps(i-1, mps.tens);
     RightNormalizeMpsTen(mps, i);
-    if(disk_flag) SaveMps(i, mps.tens);
   }
-  if(disk_flag) SaveMps(to-1, mps.tens);
 }
 
 

--- a/include/gqmps2/detail/two_site_algo_impl_with_noise.h
+++ b/include/gqmps2/detail/two_site_algo_impl_with_noise.h
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+/*
+* Author: Hao-Xin Wang <wanghx18@mails.tsinghua.edu.cn>
+* Creation Date: 2020-07-22
+*
+* Description: GraceQ/MPS2 project. Implementation details for two-site algorithm, with support for noise.
+* Reference: Arxiv: 1501.05504v2
+*/
+#include "gqmps2/gqmps2.h"
+#include "gqten/gqten.h"
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <string>
+
+#include <assert.h>
+
+#ifdef Release
+#define NDEBUG
+#endif
+
+
+namespace gqmps2 {
+using namespace gqten;
+// Forward declarations
+template <typename TenType>
+void InplaceExpand(TenType* &A,TenType* B,int i);
+template <typename TenType>
+double TwoSiteUpdate(
+  const long i,
+  std::vector<TenType *> &mps,
+  const std::vector<TenType *> &mpo,
+  std::vector<TenType*> &lblocks,
+  std::vector<TenType *> &rblocks,
+  const SweepParams &sweep_params, const char dir, const double noise);
+
+template <typename TenElemType>
+void FuseIndex(GQTensor<TenElemType>* &T, int i, int j);
+
+inline double MeasureEE(const DGQTensor *s, const long sdim);
+inline std::string GenBlockFileName(const std::string &dir, const long blk_len);
+inline void RemoveFile(const std::string &file);
+template<typename TenType>
+std::pair<std::vector<TenType *>, std::vector<TenType *>> InitBlocks(
+  const std::vector<TenType *> &mps, const std::vector<TenType *> &mpo,
+  const SweepParams &sweep_params);
+
+// Two-site algorithm
+template <typename TenType>
+double TwoSiteAlgorithm(
+  std::vector<TenType *> &mps, const std::vector<TenType *> &mpo,
+  const SweepParams &sweep_params, std::vector<double> noise) {
+  if ( sweep_params.FileIO && !IsPathExist(kRuntimeTempPath)) {
+    CreatPath(kRuntimeTempPath);
+  }
+
+  while(noise.size()<sweep_params.Sweeps){
+    noise.push_back(0.0);
+  }
+  auto l_and_r_blocks = InitBlocks(mps, mpo, sweep_params);
+
+  std::cout << "\n";
+  double e0;
+  Timer sweep_timer("sweep");
+  for (long sweep = 0; sweep < sweep_params.Sweeps; ++sweep) {
+    std::cout << "sweep " << sweep << std::endl;
+    sweep_timer.Restart();
+    e0 = TwoSiteSweep(
+      mps, mpo,
+      l_and_r_blocks.first, l_and_r_blocks.second,
+      sweep_params, noise[sweep]);
+    sweep_timer.PrintElapsed();
+    std::cout << "\n";
+  }
+  return e0;
+}
+
+
+template <typename TenType>
+double TwoSiteSweep(
+  std::vector<TenType *> &mps, const std::vector<TenType *> &mpo,
+  std::vector<TenType *> &lblocks, std::vector<TenType *> &rblocks,
+  const SweepParams &sweep_params,const double noise_sweep) {
+  auto N = mps.size();
+  double e0;
+  for (size_t i = 0; i < N-1; ++i) {
+    e0 = TwoSiteUpdate(i, mps, mpo, lblocks, rblocks, sweep_params, 'r',noise_sweep);
+  }
+  for (size_t i = N-1; i > 0; --i) {
+    e0 = TwoSiteUpdate(i, mps, mpo, lblocks, rblocks, sweep_params, 'l',noise_sweep);
+  }
+  return e0;
+}
+
+
+template <typename TenType>
+double TwoSiteUpdate(
+  const long i,
+  std::vector<TenType *> &mps,
+  const std::vector<TenType *> &mpo,
+  std::vector<TenType*> &lblocks,
+  std::vector<TenType *> &rblocks,
+  const SweepParams &sweep_params, const char dir, const double noise) {
+  Timer update_timer("update");
+  update_timer.Restart();
+
+#ifdef GQMPS2_TIMING_MODE
+  Timer bef_lanc_timer("bef_lanc");
+  bef_lanc_timer.Restart();
+#endif
+  auto N = mps.size();
+  std::vector<std::vector<long>> init_state_ctrct_axes, us_ctrct_axes;
+  std::string where;
+  long svd_ldims, svd_rdims;
+  long lsite_idx, rsite_idx;
+  long lblock_len, rblock_len;
+  std::string lblock_file, rblock_file;
+
+  switch (dir) {
+    case 'r':
+      lsite_idx = i;
+      rsite_idx = i + 1;
+      lblock_len = i;
+      rblock_len = N - (i + 2);
+      if (i == 0) {
+        init_state_ctrct_axes = {{1}, {0}};
+        where = "lend";
+        svd_ldims = 1;
+        svd_rdims = 2;
+      } else if (i == N-2) {
+        init_state_ctrct_axes = {{2}, {0}};
+        where = "rend";
+        svd_ldims = 2;
+        svd_rdims = 1;
+      } else {
+        init_state_ctrct_axes = {{2}, {0}};
+        where = "cent";
+        svd_ldims = 2;
+        svd_rdims = 2;
+      }
+      break;
+    case 'l':
+      lsite_idx = i-1;
+      rsite_idx = i;
+      lblock_len = i-1;
+      rblock_len = N-i-1;
+      if (i == N-1) {
+        init_state_ctrct_axes = {{2}, {0}};
+        where = "rend";
+        svd_ldims = 2;
+        svd_rdims = 1;
+        us_ctrct_axes = {{2}, {0}};
+      } else if (i == 1) {
+        init_state_ctrct_axes = {{1}, {0}};
+        where = "lend";
+        svd_ldims = 1;
+        svd_rdims = 2;
+        us_ctrct_axes = {{1}, {0}};
+      } else {
+        init_state_ctrct_axes = {{2}, {0}};
+        where = "cent";
+        svd_ldims = 2;
+        svd_rdims = 2;
+        us_ctrct_axes = {{2}, {0}};
+      }
+      break;
+    default:
+      std::cout << "dir must be 'r' or 'l', but " << dir << std::endl;
+      exit(1);
+  }
+
+  if (sweep_params.FileIO) {
+    switch (dir) {
+      case 'r':
+        rblock_file = GenBlockFileName("r", rblock_len);
+        ReadGQTensorFromFile(rblocks[rblock_len], rblock_file);
+        if (rblock_len != 0) {
+          RemoveFile(rblock_file);
+        }
+        break;
+      case 'l':
+        lblock_file = GenBlockFileName("l", lblock_len);
+        ReadGQTensorFromFile(lblocks[lblock_len], lblock_file);
+        if (lblock_len != 0) {
+          RemoveFile(lblock_file);
+        }
+        break;
+      default:
+        std::cout << "dir must be 'r' or 'l', but " << dir << std::endl;
+        exit(1);
+    }
+  }
+
+#ifdef GQMPS2_TIMING_MODE
+  bef_lanc_timer.PrintElapsed();
+#endif
+
+// Lanczos
+  std::vector<TenType *>eff_ham(4);
+  eff_ham[0] = lblocks[lblock_len];
+  eff_ham[1] = mpo[lsite_idx];
+  eff_ham[2] = mpo[rsite_idx];
+  eff_ham[3] = rblocks[rblock_len];
+  auto init_state = Contract(
+    *mps[lsite_idx], *mps[rsite_idx],
+    init_state_ctrct_axes);
+
+  Timer lancz_timer("Lancz");
+  lancz_timer.Restart();
+
+  auto lancz_res = LanczosSolver(
+    eff_ham, init_state,
+    sweep_params.LanczParams,
+    where);
+
+#ifdef GQMPS2_TIMING_MODE
+  auto lancz_elapsed_time = lancz_timer.PrintElapsed();
+#else
+  auto lancz_elapsed_time = lancz_timer.Elapsed();
+#endif
+
+// SVD
+#ifdef GQMPS2_TIMING_MODE
+  Timer svd_timer("svd");
+  svd_timer.Restart();
+#endif
+  TenType* svd_pu = new TenType();
+  TenType* svd_pv = new TenType();
+  GQTensor<GQTEN_Double> * svd_ps = new GQTensor<GQTEN_Double>();
+  double svd_truncation_error;
+  long svd_D; //final bond dimension
+
+  if(std::fabs(noise)==0||( dir=='r' && i==N-2  )||( dir=='l' && i == 1  )){
+    // We do nothing
+  }else if(i==0 && dir=='r' ){
+    auto P=Contract(*lancz_res.gs_vec, *eff_ham[1], {{0}, {0}});
+    InplaceContract(P, noise*(*eff_ham[2]), {{0, 2}, {1, 0}});
+    P->Transpose({1,2,3,0});
+    FuseIndex(P,2,3);
+    InplaceExpand( lancz_res.gs_vec, P, 2);
+    Index ExtendedSubSpace = InverseIndex(P->indexes[2]);
+    delete P;
+    //assume N>3
+    auto ExtendedZeroTensor = TenType({ExtendedSubSpace, mps[i+2]->indexes[1],mps[i+2]->indexes[2]});
+    InplaceExpand(mps[i+2], &ExtendedZeroTensor,0 );
+  }else if(i==N-1 && dir =='l'){
+    auto P = Contract(*lancz_res.gs_vec, *eff_ham[2],{{2},{0} });
+    InplaceContract(P, noise*(*eff_ham[1]),{{1,2 },{1,3} });
+    P->Transpose({0,2,3,1});
+    FuseIndex(P,0,1);
+
+    InplaceExpand( lancz_res.gs_vec, P, 0);
+    auto ExtendedSubSpace = InverseIndex(P->indexes[0]);
+    delete P;
+    //assume N>3
+    auto ExtendedZeroTensor =TenType({mps[i-2]->indexes[0],mps[i-2]->indexes[1],ExtendedSubSpace});
+    InplaceExpand(mps[i-2], &ExtendedZeroTensor,2 );
+
+  }else if( dir =='r') {
+    // P = eff_ham[0]*mpo[i]*mps[i]*mpo[i+1]*mps[i+1]
+    auto P = Contract(*eff_ham[0], *lancz_res.gs_vec, {{0},{0}});
+    InplaceContract(P, *eff_ham[1], {{0, 2},{0, 1}});
+    InplaceContract(P, noise*(*eff_ham[2]), {{4, 1},{0, 1}});
+    P->Transpose({0, 2, 3, 4, 1});//-> index combine 0,1,2,{3,4} -> P
+    FuseIndex(P,3,4);
+    InplaceExpand( lancz_res.gs_vec, P, 3);
+    auto ExtendedSubSpace =InverseIndex(P->indexes[3]) ;
+    delete P;
+    TenType ExtendedZeroTensor;
+    if(i!=N-3){
+      ExtendedZeroTensor = TenType({ExtendedSubSpace, mps[i+2]->indexes[1],mps[i+2]->indexes[2]});
+    }else{
+      ExtendedZeroTensor =TenType({ExtendedSubSpace, mps[i+2]->indexes[1]});
+    }
+    InplaceExpand(mps[i+2], &ExtendedZeroTensor,0 );
+  }else{ //dir =='l'
+    // P = eff_ham[4]*mpo[i]*mps[i]*mpo[i-1]*mps[i-1]
+    auto P = Contract(*lancz_res.gs_vec,*eff_ham[3],{{3},{0}});
+    InplaceContract(P,*eff_ham[2],{{2,3},{1,3}});
+    InplaceContract(P,noise*(*eff_ham[1]),{{1,3},{1,3}});
+    P->Transpose({0,3,4,2,1});
+    FuseIndex(P, 0,1);
+    InplaceExpand( lancz_res.gs_vec, P, 0);
+    auto ExtendedSubSpace = InverseIndex(P->indexes[0]);
+    delete P;
+    if(i!=2){
+      auto ExtendedZeroTensor =TenType({mps[i-2]->indexes[0],mps[i-2]->indexes[1],ExtendedSubSpace});
+      InplaceExpand(mps[i-2], &ExtendedZeroTensor,2 );
+    }else{
+      auto ExtendedZeroTensor =TenType({mps[i-2]->indexes[0],ExtendedSubSpace});
+      InplaceExpand(mps[i-2], &ExtendedZeroTensor,1 );
+    }
+  }
+
+  Svd(lancz_res.gs_vec,
+      svd_ldims, svd_rdims,
+      Div(*mps[lsite_idx]), Div(*mps[rsite_idx]),
+      sweep_params.Cutoff,
+      sweep_params.Dmin, sweep_params.Dmax,
+      svd_pu, svd_ps, svd_pv,
+      &svd_truncation_error, &svd_D);
+
+
+#ifdef GQMPS2_TIMING_MODE
+  svd_timer.PrintElapsed();
+#endif
+
+  delete lancz_res.gs_vec;
+
+// Measure entanglement entropy.
+  auto ee = MeasureEE(svd_ps, svd_D);
+// Update MPS sites and blocks.
+#ifdef GQMPS2_TIMING_MODE
+  Timer blk_update_timer("blk_update");
+  blk_update_timer.Restart();
+  Timer new_blk_timer("gen_new_blk");
+  Timer dump_blk_timer("dump_blk");
+#endif
+
+  TenType *new_lblock, *new_rblock;
+  bool update_block = true;
+  switch (dir) {
+    case 'r':
+
+#ifdef GQMPS2_TIMING_MODE
+      new_blk_timer.Restart();
+#endif
+
+      delete mps[lsite_idx];
+      mps[lsite_idx] = svd_pu;
+      delete mps[rsite_idx];
+      mps[rsite_idx] = Contract(*svd_ps, *svd_pv, {{1}, {0}});
+      delete svd_ps;
+      delete svd_pv;
+
+      if (i == 0) {
+        new_lblock = Contract(*mps[i], *mpo[i], {{0}, {0}});
+        auto temp_new_lblock = Contract(
+          *new_lblock, Dag(*mps[i]),
+          {{2}, {0}});
+        delete new_lblock;
+        new_lblock = temp_new_lblock;
+      } else if (i != N-2) {
+        new_lblock = Contract(*lblocks[i], *mps[i], {{0}, {0}});
+        auto temp_new_lblock = Contract(*new_lblock, *mpo[i], {{0, 2}, {0, 1}});
+        delete new_lblock;
+        new_lblock = temp_new_lblock;
+        temp_new_lblock = Contract(*new_lblock, Dag(*mps[i]), {{0, 2}, {0, 1}});
+        delete new_lblock;
+        new_lblock = temp_new_lblock;
+      } else {
+        update_block = false;
+      }
+
+#ifdef GQMPS2_TIMING_MODE
+      new_blk_timer.PrintElapsed();
+      dump_blk_timer.Restart();
+#endif
+
+      if (sweep_params.FileIO) {
+        if (update_block) {
+          auto target_blk_len = i+1;
+          lblocks[target_blk_len] = new_lblock;
+          auto target_blk_file = GenBlockFileName("l", target_blk_len);
+          WriteGQTensorTOFile(*new_lblock, target_blk_file);
+          delete eff_ham[0];
+          delete eff_ham[3];
+        } else {
+          delete eff_ham[0];
+        }
+      } else {
+        if (update_block) {
+          auto target_blk_len = i+1;
+          delete lblocks[target_blk_len];
+          lblocks[target_blk_len] = new_lblock;
+        }
+      }
+
+#ifdef GQMPS2_TIMING_MODE
+      dump_blk_timer.PrintElapsed();
+#endif
+
+      break;
+    case 'l':
+
+#ifdef GQMPS2_TIMING_MODE
+      new_blk_timer.Restart();
+#endif
+
+      delete mps[lsite_idx];
+      mps[lsite_idx] = Contract(*svd_pu, *svd_ps, us_ctrct_axes);
+      delete svd_pu;
+      delete svd_ps;
+      delete mps[rsite_idx];
+      mps[rsite_idx] = svd_pv;
+
+      if (i == N-1) {
+        new_rblock = Contract(*mps[i], *mpo[i], {{1}, {0}});
+        auto temp_new_rblock = Contract(*new_rblock, Dag(*mps[i]), {{2}, {1}});
+        delete new_rblock;
+        new_rblock = temp_new_rblock;
+      } else if (i != 1) {
+        new_rblock = Contract(*mps[i], *eff_ham[3], {{2}, {0}});
+        auto temp_new_rblock = Contract(*new_rblock, *mpo[i], {{1, 2}, {1, 3}});
+        delete new_rblock;
+        new_rblock = temp_new_rblock;
+        temp_new_rblock = Contract(*new_rblock, Dag(*mps[i]), {{3, 1}, {1, 2}});
+        delete new_rblock;
+        new_rblock = temp_new_rblock;
+      } else {
+        update_block = false;
+      }
+
+#ifdef GQMPS2_TIMING_MODE
+      new_blk_timer.PrintElapsed();
+      dump_blk_timer.Restart();
+#endif
+
+      if (sweep_params.FileIO) {
+        if (update_block) {
+          auto target_blk_len = N-i;
+          rblocks[target_blk_len] = new_rblock;
+          auto target_blk_file = GenBlockFileName("r", target_blk_len);
+          WriteGQTensorTOFile(*new_rblock, target_blk_file);
+          delete eff_ham[0];
+          delete eff_ham[3];
+        } else {
+          delete eff_ham[3];
+        }
+      } else {
+        if (update_block) {
+          auto target_blk_len = N-i;
+          delete rblocks[target_blk_len];
+          rblocks[target_blk_len] = new_rblock;
+        }
+      }
+
+#ifdef GQMPS2_TIMING_MODE
+      dump_blk_timer.PrintElapsed();
+#endif
+
+  }
+
+#ifdef GQMPS2_TIMING_MODE
+  blk_update_timer.PrintElapsed();
+#endif
+
+  auto update_elapsed_time = update_timer.Elapsed();
+  std::cout << "Site " << std::setw(4) << i
+            << " E0 = " << std::setw(20) << std::setprecision(kLanczEnergyOutputPrecision) << std::fixed << lancz_res.gs_eng
+            << " TruncErr = " << std::setprecision(2) << std::scientific << svd_truncation_error<< std::fixed
+            << " D = " << std::setw(5) << svd_D
+            << " Iter = " << std::setw(3) << lancz_res.iters
+            << " LanczT = " << std::setw(8) << lancz_elapsed_time
+            << " TotT = " << std::setw(8) << update_elapsed_time
+            << " S = " << std::setw(10) << std::setprecision(7) << ee;
+  std::cout << std::scientific << std::endl;
+  return lancz_res.gs_eng;
+}
+
+/** FuseIndex
+ *  Fuse 2 indices i and j of tensor T, inplacement operation.
+ * @tparam TenElemType
+ * @param T
+ * @param i
+ * @param j
+ */
+template <typename TenElemType>
+void FuseIndex(GQTensor<TenElemType>* &T, int i, int j){
+  assert(T->indexes[i].dir==T->indexes[j].dir);
+  GQTensor<TenElemType> C = IndexCombine<TenElemType>(
+    InverseIndex(T->indexes[i]),InverseIndex(T->indexes[j]), T->indexes[i].dir);
+  InplaceContract(T,C, {{i,j}, {0,1}});
+  int legnumber = T->indexes.size();
+  std::vector<long> axs(legnumber);
+  for(int k=0;k<legnumber;k++){
+    if(k<i) axs[k]=k;
+    else if(k==i) axs[k]=legnumber-1;
+    else axs[k]=k-1;
+  }
+  T->Transpose(axs);
+}
+/** InplaceExpand
+ * Inplacement version of Expand function,only expand on one index
+ * @tparam TenType
+ * @param A
+ * @param B
+ * @param i
+ */
+template <typename TenType>
+void InplaceExpand(TenType* &A,TenType* B,int i){
+TenType* C = new TenType();
+std::vector<size_t> axs= {(unsigned long)i};
+Expand(A,B, axs, C);
+delete A;
+A = C;
+}
+
+} /* gqmps2 */

--- a/include/gqmps2/gqmps2.h
+++ b/include/gqmps2/gqmps2.h
@@ -112,8 +112,8 @@ public:
 
   void AddTerm(
     const TenElemType coef,
-    const GQTensorVec &phys_ops,
-    const std::vector<long> &idxs,
+    GQTensorVec phys_ops,
+    std::vector<long> idxs,
     const GQTensorVec &inst_ops,
     const std::vector<long> &inst_idxs);
 

--- a/include/gqmps2/gqmps2.h
+++ b/include/gqmps2/gqmps2.h
@@ -229,11 +229,11 @@ double TwoSiteAlgorithm(
 
 
 template <typename TenType>
-double TwoSiteAlgorithm( //Add by wanghx in June 21, 2020.
+double TwoSiteAlgorithm(
   std::vector<TenType *> &,
   const std::vector<TenType *> &,
   const SweepParams &,
-  std::vector<double>);// Add a parameter noise
+  std::vector<double>);
 
 // MPS operations.
 template <typename TenType>
@@ -294,26 +294,35 @@ template <typename AvgType>
 using MeasuResSet = std::vector<MeasuRes<AvgType>>;
 
 
-// Single site operator.
+/// Single site operator. Uniform indices version
 template <typename TenElemType>
 MeasuRes<TenElemType> MeasureOneSiteOp(
     MPS<GQTensor<TenElemType>> &,
     const GQTensor<TenElemType> &, const std::string &);
 
-
+/// For non-uniform indices
 template <typename TenElemType>
-MeasuRes<TenElemType> MeasureOneSiteOp(//Add by wanghx June 29
+MeasuRes<TenElemType> MeasureOneSiteOp(
   MPS<GQTensor<TenElemType>> &,
   const GQTensor<TenElemType> &,
-  const std::vector<long> &site_set,//For nonuniform hilbert space we must
-    const std::string &);//specify which sites are be measured
+  const std::vector<long> &site_set, //specify which site are be measured
+  const std::string &);
 
 template <typename TenElemType>
 MeasuResSet<TenElemType> MeasureOneSiteOp(
     MPS<GQTensor<TenElemType>> &,
-    const std::vector<GQTensor<TenElemType>> &, //physical operator
+    const std::vector<GQTensor<TenElemType>> &,
     const std::vector<std::string> &);
 
+template <typename TenElemType>
+MeasuRes<TenElemType> MeasureOneSiteOp(
+  MPS<GQTensor<TenElemType>> &,
+  const GQTensor<TenElemType> &,
+  const std::vector<long> &site_set,//For nonuniform hilbert space we must
+  const std::string &);//specify which sites are be measured
+
+  /// The insertion operators are inserted in all the sites between physical opeartors
+  /// usually for uniform indices
 template <typename TenElemType>
 MeasuRes<TenElemType> MeasureTwoSiteOp(
     MPS<GQTensor<TenElemType>> &,
@@ -322,13 +331,16 @@ MeasuRes<TenElemType> MeasureTwoSiteOp(
     const std::vector<std::vector<long>> &, // physical operator sites
     const std::string &);
 
+/// No insertion operators, can be used for uniform or non-uniform indices
 template <typename TenElemType>
 MeasuRes<TenElemType> MeasureTwoSiteOp(
   MPS<GQTensor<TenElemType>> &mps,
   const std::vector<GQTensor<TenElemType>> &phys_ops, //physical operator
   const std::vector<std::vector<long>> &sites_set, //physical operator sites
-  const std::string &res_file_basename); //< no insertion operator
+  const std::string &res_file_basename);
 
+  /// For compatibility of old version, where we should input an indentity operator.
+  /// For uniform indices
 template <typename TenElemType>
 MeasuRes<TenElemType> MeasureTwoSiteOp(
   MPS<GQTensor<TenElemType>> & mps,
@@ -340,6 +352,17 @@ MeasuRes<TenElemType> MeasureTwoSiteOp(
   return MeasureTwoSiteOp(mps, op_set,insertop,site_set,filename);
 }
 
+/// Specify which sites are be inserted, can be used for non-uniform indices
+template <typename TenElemType>
+MeasuRes<TenElemType> MeasureTwoSiteOp(
+  MPS<GQTensor<TenElemType>> &mps,
+  const std::vector<GQTensor<TenElemType>> &phys_ops,
+  const std::vector<std::vector<long>> &sites_set,
+  const std::vector<std::vector<long>> &insertsite_set,
+  const std::string &res_file_basename);
+
+/// The insertion operators are inserted in all the sites between physical opeartors
+/// usually for uniform indices
 template <typename TenElemType>
 MeasuRes<TenElemType> MeasureMultiSiteOp(
     MPS<GQTensor<TenElemType>> &,
@@ -348,6 +371,9 @@ MeasuRes<TenElemType> MeasureMultiSiteOp(
     const std::vector<std::vector<long>> &,
     const std::string &);
 
+
+/// For compatibility of old version, where we should input an indentity operator.
+/// For uniform indices
 template <typename TenElemType>
 MeasuRes<TenElemType> MeasureMultiSiteOp(
   MPS<GQTensor<TenElemType>> & mps,
@@ -359,6 +385,8 @@ MeasuRes<TenElemType> MeasureMultiSiteOp(
   return MeasureMultiSiteOp(mps, phy_op,ins_op, site_set,filename);
 }
 
+
+/// Specify which sites are be inserted, can be used for non-uniform indices
 template <typename TenElemType>
 MeasuRes<TenElemType> MeasureMultiSiteOp(
   MPS<GQTensor<TenElemType>> &mps,
@@ -408,6 +436,7 @@ inline void CreatPath(const std::string &path) {
 #include "gqmps2/detail/lanczos_impl.h"
 #include "gqmps2/detail/mpogen/mpogen_impl.h"
 #include "gqmps2/detail/two_site_algo_impl.h"
+#include "gqmps2/detail/two_site_algo_impl_with_noise.h"
 #include "gqmps2/detail/mps_ops_impl.h"
 #include "gqmps2/detail/mps_measu_impl.h"
 

--- a/tests/test_mps_measu.cc
+++ b/tests/test_mps_measu.cc
@@ -9,7 +9,7 @@
 #include "gqten/gqten.h"
 
 #include "gtest/gtest.h"
-
+#include <stdlib.h>
 
 using namespace gqmps2;
 using namespace gqten;
@@ -76,6 +76,18 @@ void RunTestMeasureOneSiteOpCase(
   }
 }
 
+///support for non-uniform index
+template <typename MpsType, typename TenElemType>
+void RunTestMeasureOneSiteOpCase(
+  MpsType &mps,
+  const GQTensor<TenElemType> &op, const std::vector<long> site_set,
+  const std::vector<TenElemType> &res) {
+  auto measu_res = MeasureOneSiteOp(mps, op,site_set, "op1");
+  assert(measu_res.size() == res.size());
+  for (size_t i = 0; i < res.size(); ++i) {
+    ExpectDoubleEq(measu_res[i].avg, res[i]);
+  }
+}
 
 TEST_F(TestMpsMeasurement, TestMeasureOneSiteOp) {
   // Double case 1
@@ -179,3 +191,89 @@ TEST_F(TestMpsMeasurement, TestMeasureTwoSiteOp) {
       zmps_for_measu2, {zntot, zntot}, zid, zid, sites_set, zres2);
   MpsFree(zmps2);
 }
+
+
+struct TestNonUniformMpsMeasurement : public testing::Test {
+  long N = 4; //unit cell number, A-B-A-B-A-B-A-B
+
+  QN qn0 = QN({QNNameVal("N", 0)});
+  Index pb_outA = Index({QNSector(QN({QNNameVal("N", 0)}), 1),
+                        QNSector(QN({QNNameVal("N", 1)}), 1)}, OUT);
+  Index pb_inA = InverseIndex(pb_outA);
+  Index pb_outB = Index({QNSector(QN({QNNameVal("N", 0)}), 2)}, OUT);
+  Index pb_inB = InverseIndex(pb_outB);
+
+  DGQTensor dntotA = DGQTensor({pb_inA, pb_outA});
+  DGQTensor didA = DGQTensor({pb_inA, pb_outA});
+  DGQTensor didB = DGQTensor({pb_inB, pb_outB});
+  DTenPtrVec dmps = DTenPtrVec(2*N);
+  std::vector<Index> pb_out_set = std::vector<Index>(2*N);
+
+  std::vector<long> stat_labs1 = std::vector<long>(2*N,1);
+  std::vector<long> A_sublattice=std::vector<long>(N);
+
+  void SetUp(void) {
+    dntotA({0, 0}) = 0;
+    dntotA({1, 1}) = 1;
+    didA({0, 0}) = 1;
+    didA({1, 1}) = 1;
+
+    didB({0, 0}) = 1;
+    didB({1, 1}) = 1;
+    srand((unsigned)time(NULL));
+    for (long i = 0; i < 2*N; ++i) {
+      if(i%2==0) pb_out_set[i]=pb_outA;
+      else pb_out_set[i]=pb_outB;
+    }
+    for (long i=0;i<N;++i){
+      A_sublattice[i]=2*i;
+      stat_labs1[2*i]= rand()%2;
+    }
+  }
+};
+
+
+TEST_F(TestNonUniformMpsMeasurement, TestNoUniformMeasureOneSiteOp) {
+  std::vector<GQTEN_Double> dres1(N);
+  for (long i = 0; i < N; ++i) { dres1[i]=stat_labs1[2*i]; }
+  auto dmps1 = dmps;
+  DirectStateInitMps(dmps1, stat_labs1, pb_out_set, qn0);
+  auto dmps_for_measu1 = MPS<DGQTensor>(dmps1, -1);
+  RunTestMeasureOneSiteOpCase(dmps_for_measu1, dntotA,A_sublattice, dres1);
+  MpsFree(dmps1);
+}
+
+///No insertion operator case, can used for uniform or non-uniform indices
+template <typename MpsType, typename TenElemType>
+void RunTestMeasureTwoSiteOpCase(
+  MpsType &mps,
+  const std::vector<GQTensor<TenElemType>> &phys_ops,
+  const std::vector<std::vector<long>> &sites_set,
+  const std::vector<TenElemType> &res) {
+  auto measu_res = MeasureTwoSiteOp(
+    mps, phys_ops, sites_set, "op1op2");
+  assert(measu_res.size() == res.size());
+  for (size_t i = 0; i < res.size(); ++i) {
+    ExpectDoubleEq(measu_res[i].avg, res[i]);
+  }
+}
+
+TEST_F(TestNonUniformMpsMeasurement, TestNoUniformMeasureTwoSiteOp) {
+std::vector<std::vector<long>> sites_set = {
+  {0, 2}, {0, 4},{2, 4}
+};
+// Double case 1
+std::vector<GQTEN_Double> dres1(sites_set.size());
+for(int i = 0;i<sites_set.size();i++){
+  long site1 = sites_set[i][0];
+  long site2 = sites_set[i][1];
+  dres1[i]=stat_labs1[site1]*stat_labs1[site2];
+}
+auto dmps1 = dmps;
+DirectStateInitMps(dmps1, stat_labs1, pb_out_set, qn0);
+auto dmps_for_measu1 = MPS<DGQTensor>(dmps1, -1);
+RunTestMeasureTwoSiteOpCase(
+  dmps_for_measu1, {dntotA, dntotA}, sites_set, dres1);
+MpsFree(dmps1);
+}
+


### PR DESCRIPTION
The update includes:
1. support for mpo with non-uniform indices;
2. initial mps with non-uniform indices;
3. add noise when update mps;
4. corresponding test.