### PR TITLE
Change the convention of MPS/MPO tensors; Add single site update algorithm

### DIFF
--- a/include/gqmps2/algorithm/vmps/single_site_update_finite_vmps_impl.h
+++ b/include/gqmps2/algorithm/vmps/single_site_update_finite_vmps_impl.h
@@ -1,0 +1,529 @@
+//
+// Created by Hao-Xin on 2021/6/12.
+//
+
+#ifndef GRACEQ_MPS2_ONE_SITE_UPDATE_FINITE_VMPS_IMPL_H
+#define GRACEQ_MPS2_ONE_SITE_UPDATE_FINITE_VMPS_IMPL_H
+
+#include "gqmps2/algorithm/vmps/two_site_update_finite_vmps.h"    // SweepParams
+#include "gqmps2/one_dim_tn/mpo/mpo.h"                            // MPO
+#include "gqmps2/one_dim_tn/mps/finite_mps/finite_mps.h"          // FiniteMPS
+#include "gqmps2/utilities.h"                                     // IsPathExist, CreatPath
+#include "gqmps2/one_dim_tn/framework/ten_vec.h"                  // TenVec
+#include "gqmps2/consts.h"
+#include "gqten/gqten.h"
+#include "gqten/utility/timer.h"                                  // Timer
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <string>
+
+#include <stdio.h>    // remove
+#ifdef Release
+#define NDEBUG
+#endif
+#include <assert.h>
+
+namespace gqmps2 {
+  using namespace gqten;
+  using std::cout;
+  using std::endl;
+  using std::vector;
+  // Helpers
+  template <typename DTenT>
+  inline double MeasureEE(const DTenT &s, const size_t sdim);
+
+  /** Fuse two indices of a tensor t. we suppose i<j, and the new index is placed on position i.
+   * Original index after index i a placed in original order.
+   */
+  template <typename TenElemType, typename QNT>
+  GQTensor<TenElemType, QNT> FuseIndex(const GQTensor<TenElemType, QNT>& t, unsigned int i, unsigned int j){
+    assert(i<j);
+    assert(i<t.Rank() && j<t.Rank());
+    assert(t.GetIndexes()[i].GetDir()==t.GetIndexes()[j].GetDir());
+    Index<QNT> index1 = t.GetIndexes()[i];
+    Index<QNT> index2 = t.GetIndexes()[j];
+
+    GQTensor<TenElemType, QNT> combiner = IndexCombine<TenElemType>(
+        InverseIndex(index1),InverseIndex(index2), index1.GetDir());
+    GQTensor<TenElemType, QNT> fused_tensor;
+    Contract(&t, &combiner, {{i,j}, {0,1}}, &fused_tensor);
+    unsigned int rank = fused_tensor.Rank();
+    std::vector<size_t> axs(rank);
+    for(size_t k=0;k<rank;k++){
+      if(k<i) axs[k]=k;
+      else if(k==i) axs[k]=rank-1;
+      else axs[k]=k-1;
+    }
+    fused_tensor.Transpose(axs);
+    return fused_tensor;
+  }
+
+  /**
+Function to perform single-site update finite vMPS algorithm.
+
+@note The input MPS will be considered an empty one.
+*/
+template <typename TenElemT, typename QNT>
+GQTEN_Double SingleSiteFiniteVMPS(
+    FiniteMPS<TenElemT, QNT> &mps,
+    const MPO<GQTensor<TenElemT, QNT>> &mpo,
+    SweepParams &sweep_params){
+    assert(mps.size() == mpo.size());
+
+    std::cout << "\n";
+    std::cout << "=====> Sweep Parameter <=====" << "\n";
+    std::cout << "MPS/MPO size: \t " << mpo.size() << "\n";
+    std::cout << "The number of sweep times: \t " << sweep_params.sweeps << "\n";
+    std::cout << "Bond dimension: \t " << sweep_params.Dmin << "/" << sweep_params.Dmax << "\n";
+    std::cout << "Cut off truncation error: \t " <<sweep_params.trunc_err <<"\n";
+    std::cout << "Lanczos max iterations \t" <<sweep_params.lancz_params.max_iterations << "\n";
+    std::cout << "Preseted noises: \t[";
+    for(size_t i = 0; i < sweep_params.noises.size() ; i++){
+      std::cout << sweep_params.noises[i];
+      if(i!=sweep_params.noises.size()-1){
+        std::cout << ", " ;
+      }else{
+        std::cout << "]\n";
+      }
+    }
+    std::cout << "MPS path: \t" << sweep_params.mps_path <<"\n";
+    std::cout << "Temp path: \t" << sweep_params.temp_path << std::endl;
+
+    // If the runtime temporary directory does not exit, create it and initialize
+    // the left/right environments
+    if (!IsPathExist(sweep_params.temp_path)) {
+      CreatPath(sweep_params.temp_path);
+      InitEnvs(mps, mpo, sweep_params, 1);
+      std::cout << "no exsiting path " <<sweep_params.temp_path
+        <<", thus progress created it and generated environment tensors."
+        <<std::endl;
+    }else{
+      std::cout << "finded exsiting path "<<sweep_params.temp_path
+        <<", thus progress will use the present environment tensors."
+        <<std::endl;
+    }
+
+    GQTEN_Double e0;
+
+    if(sweep_params.noises.size()==0) sweep_params.noises.push_back(0.0);
+    double noise_start;
+    mps.LoadTen(0,GenMPSTenName(sweep_params.mps_path, 0));
+    for (size_t sweep = 1; sweep <= sweep_params.sweeps; ++sweep) {
+      if(sweep-1 < sweep_params.noises.size()){
+        noise_start = sweep_params.noises[sweep-1];
+      }else{
+        //do nothing, using the last sweep returned noise
+      }
+      std::cout << "sweep " << sweep << std::endl;
+      Timer sweep_timer("sweep");
+      e0 = SingleSiteFiniteVMPSSweep(mps, mpo, sweep_params, noise_start);
+      sweep_timer.PrintElapsed();
+      std::cout << "\n";
+    }
+    mps.DumpTen(0,GenMPSTenName(sweep_params.mps_path, 0),true);
+    return e0;
+}
+
+template <typename TenElemT, typename QNT>
+double SingleSiteFiniteVMPSSweep(
+    FiniteMPS<TenElemT, QNT> &mps,
+    const MPO<GQTensor<TenElemT, QNT>> &mpo,
+    const SweepParams &sweep_params,
+    double& noise_start) {
+  auto N = mps.size();
+  using TenT = GQTensor<TenElemT, QNT>;
+  TenVec<TenT> lenvs(N), renvs(N);
+  double e0(0.0), actual_e0(0.0), laststep_e0(1000.0), actual_laststep_e0(0.0);
+
+  double& noise_running = noise_start;
+  for (size_t i = 0; i < N - 1; ++i) {
+    LoadRelatedTensSingleSiteAlg(mps, lenvs, renvs, i, 'r', sweep_params);
+// note: here we need mps[i](do not need load), mps[i+1], lenvs[i](do not need load), and mps[i]'s renvs
+// mps[i]'s renvs can be removed
+
+    actual_e0 = CalEnergyEptSingleSite(mps, mpo,lenvs, renvs, i);
+    if(actual_e0-laststep_e0 <= 0.0){
+      //expand and truncate let the energy lower or not change
+      // this case is very rare, but include the boundary mps tensor case
+      // so we do nothing now
+    }else if(actual_e0-laststep_e0 >= fabs(actual_laststep_e0-laststep_e0)){
+      //below two case suppose actual_laststep_e0-laststep_e0>0, usually it is right
+      noise_running=noise_running*0.9;
+    }else{
+      noise_running = std::min(noise_running*1.05, 1.0);
+    }
+    e0 = SingleSiteFiniteVMPSUpdate(mps, lenvs, renvs, mpo, sweep_params, 'r', i, noise_running);
+    laststep_e0 = e0;
+    actual_laststep_e0 = actual_e0;
+    DumpRelatedTensSingleSiteAlg(mps, lenvs, renvs, i, 'r', sweep_params);
+// note: here we need dump mps[i](free memory), lenvs[i+1](without free memory)
+  }
+  for (size_t i = N-1; i > 0; --i) {
+    LoadRelatedTensSingleSiteAlg(mps, lenvs, renvs, i, 'l', sweep_params);
+    actual_e0 = CalEnergyEptSingleSite(mps, mpo,lenvs, renvs, i);
+    if(actual_e0-laststep_e0 <= 0.0){
+      //expand and truncate let the energy lower or not change
+      // this case is very rare, but include the boundary mps tensor case
+      // so we do nothing now
+    }else if(actual_e0-laststep_e0 >= fabs(actual_laststep_e0-laststep_e0)){
+      //below two case suppose actual_laststep_e0-laststep_e0>0, usually it is right
+      noise_running=noise_running*0.9;
+    }else{
+      noise_running = std::min(noise_running*1.05, 1.0);
+    }
+    e0 = SingleSiteFiniteVMPSUpdate(mps, lenvs, renvs, mpo, sweep_params, 'l', i, noise_running);
+    laststep_e0 = e0;
+    actual_laststep_e0 = actual_e0;
+    DumpRelatedTensSingleSiteAlg(mps, lenvs, renvs, i, 'l', sweep_params);
+  }
+  return e0;
+}
+
+/**  Single step for single site update.
+ *  This function includes below procedure:
+ *    ** update mps[target] tensors according corresponding environment tensors and the mpo tensor,
+ *       using lanczos algorithm;
+ *    ** expand mps[target] and mps[next_site] by noise, if need
+ *    ** canonicalize mps to mps[next_site] by svd, while truncate tensor mps[target] if need
+ *    ** generate the next environment in the direction.
+ */
+template <typename TenElemT, typename QNT>
+double SingleSiteFiniteVMPSUpdate(
+    FiniteMPS<TenElemT, QNT> &mps,
+    TenVec<GQTensor<TenElemT, QNT>> &lenvs,
+    TenVec<GQTensor<TenElemT, QNT>> &renvs,
+    const MPO<GQTensor<TenElemT, QNT>> &mpo,
+    const SweepParams &sweep_params,
+    const char dir,
+    const size_t target_site,
+    double& noise
+  ){
+  Timer update_timer("single_site_fvmps_update");
+
+#ifdef GQMPS2_TIMING_MODE
+  Timer preprocessing_timer("single_site_fvmps_preprocessing");
+#endif
+  auto N = mps.size();
+  unsigned lenv_len = target_site;
+  unsigned renv_len = N - target_site - 1;
+  unsigned svd_ldims;
+  unsigned next_site;
+  switch (dir) {
+    case 'r':
+      svd_ldims=2;
+      next_site=target_site+1;
+      break;
+    case 'l':
+      svd_ldims=1;
+      next_site=target_site-1;
+      break;
+    default:
+      std::cout << "dir must be 'r' or 'l', but " << dir << std::endl;
+      exit(3);
+  }
+
+  using TenT = GQTensor<TenElemT, QNT>;
+  std::vector<TenT *>eff_ham(3);
+  eff_ham[0] = lenvs(lenv_len);
+  // Safe const casts for MPO local tensors.
+  eff_ham[1] = const_cast<TenT *>(&mpo[target_site]);
+  eff_ham[2] = renvs(renv_len);
+
+  std::vector<size_t> mps_ten_shape = mps[target_site].GetShape();
+  Timer lancz_timer("single_site_fvmps_lancz");
+  auto lancz_res = LanczosSolver(
+      eff_ham, mps(target_site),
+      &eff_ham_mul_single_site_state,
+      sweep_params.lancz_params);//note here mps(target_site) are destroyed.
+#ifdef GQMPS2_TIMING_MODE
+auto lancz_elapsed_time = lancz_timer.PrintElapsed();
+#else
+auto lancz_elapsed_time = lancz_timer.Elapsed();
+#endif
+  bool need_expand(true);
+
+  if(fabs(noise)<1e-15){need_expand=false;}
+  else if( target_site < N/2 && mps_ten_shape[0]*mps_ten_shape[1]<=mps_ten_shape[2]){need_expand= false;}
+  else if( target_site > N/2 && mps_ten_shape[2]*mps_ten_shape[1]<=mps_ten_shape[0]){need_expand= false;}
+  Timer expand_timer("single_site_fvmps_expand");
+  if(need_expand){
+    SingleSiteFiniteVMPSExpand( lancz_res.gs_vec, mps, eff_ham, dir, target_site, noise);
+    delete lancz_res.gs_vec;
+  }else{
+    mps(target_site) = lancz_res.gs_vec;
+  }
+
+#ifdef GQMPS2_TIMING_MODE
+    auto expand_elapsed_time = expand_timer.PrintElapsed();
+#else
+    auto expand_elapsed_time = expand_timer.Elapsed();
+#endif
+#ifdef GQMPS2_TIMING_MODE
+    Timer svd_timer("single_site_fvmps_svd");
+#endif
+
+    TenT u, vt;
+    GQTensor<GQTEN_Double, QNT> s;
+    GQTEN_Double actual_trunc_err;
+    size_t D;
+    QNT zero_div = Div(mps[target_site])-Div(mps[target_site]);
+    QNT div_left = (dir=='r'? Div(mps[target_site]): zero_div );
+    SVD(
+        mps(target_site),
+        svd_ldims, div_left,
+        sweep_params.trunc_err, sweep_params.Dmin, sweep_params.Dmax,
+        &u, &s, &vt, &actual_trunc_err, &D
+    );
+    auto ee = MeasureEE(s, D);
+
+#ifdef GQMPS2_TIMING_MODE
+    svd_timer.PrintElapsed();
+#endif
+
+
+#ifdef GQMPS2_TIMING_MODE
+    Timer update_mps_ten_timer("single_site_fvmps_update_mps_ten");
+#endif
+    TenT* temp_ten1 = new TenT();
+    TenT* temp_ten2 = new TenT();
+  switch(dir){
+    case 'r':
+      mps[target_site] = std::move(u);
+      Contract(&s, &vt, {{1}, {0}}, temp_ten1);
+      Contract(temp_ten1, mps(next_site), {{1},{0}},temp_ten2);
+      delete temp_ten1; delete mps(next_site);
+      mps(next_site)= temp_ten2;
+      break;
+    case 'l':
+      mps[target_site] = std::move(vt);
+      Contract(&u, &s, {{1}, {0}}, temp_ten1);
+      Contract(mps(next_site), temp_ten1, {{2}, {0}}, temp_ten2);
+      delete temp_ten1; delete mps(next_site);
+      mps(next_site) =temp_ten2;
+      break;
+  }
+
+
+#ifdef GQMPS2_TIMING_MODE
+    update_mps_ten_timer.PrintElapsed();
+#endif
+
+    // Update environment tensors
+#ifdef GQMPS2_TIMING_MODE
+    Timer update_env_ten_timer("single_site_fvmps_update_env_ten");
+#endif
+    switch (dir) {
+      case 'r':{
+        TenT temp1, temp2, lenv_ten;
+        Contract(&lenvs[lenv_len], &mps[target_site], {{0}, {0}}, &temp1);
+        Contract(&temp1, &mpo[target_site], {{0, 2}, {0, 1}}, &temp2);
+        auto mps_ten_dag = Dag(mps[target_site]);
+        Contract(&temp2, &mps_ten_dag, {{0 ,2}, {0, 1}}, &lenv_ten);
+        lenvs[lenv_len + 1] = std::move(lenv_ten);
+      }break;
+      case 'l':{
+        TenT temp1, temp2, renv_ten;
+        Contract(&mps[target_site], eff_ham[2], {{2}, {0}}, &temp1);
+        Contract(&temp1, &mpo[target_site], {{1, 2}, {1, 3}}, &temp2);
+        auto mps_ten_dag = Dag(mps[target_site]);
+        Contract(&temp2, &mps_ten_dag, {{3, 1}, {1, 2}}, &renv_ten);
+        renvs[renv_len + 1] = std::move(renv_ten);
+      }break;
+      default:
+        assert(false);
+    }
+#ifdef GQMPS2_TIMING_MODE
+    update_env_ten_timer.PrintElapsed();
+#endif
+
+
+    auto update_elapsed_time = update_timer.Elapsed();
+    std::cout << "Site " << std::setw(4) << target_site
+              << " E0 = " << std::setw(20) << std::setprecision(kLanczEnergyOutputPrecision) << std::fixed << lancz_res.gs_eng
+              << " noise = " <<  std::setprecision(2) << std::scientific  << noise << std::fixed
+              << " TruncErr = " << std::setprecision(2) << std::scientific << actual_trunc_err << std::fixed
+              << " D = " << std::setw(5) << D
+              << " Iter = " << std::setw(3) << lancz_res.iters
+              << " LanczT = " << std::setw(8) << lancz_elapsed_time
+              << " ExpandT = " << std::setw(8) << expand_elapsed_time
+              << " TotT = " << std::setw(8) << update_elapsed_time
+              << " S = " << std::setw(10) << std::setprecision(7) << ee;
+    if(!need_expand){
+      std::cout << "(no noise)";
+    }
+    std::cout << std::scientific << std::endl;
+    return lancz_res.gs_eng;
+}
+
+template <typename TenElemT, typename QNT>
+void SingleSiteFiniteVMPSExpand(
+    GQTensor<TenElemT, QNT>* gs_vec,
+    FiniteMPS<TenElemT, QNT> &mps,
+    std::vector< GQTensor<TenElemT, QNT> *> eff_ham,
+    const char dir,
+    const size_t target_site,
+    double noise
+    ){
+  // we suppose mps only contain mps[next_site]
+  using TenT = GQTensor<TenElemT, QNT>;
+  TenT* ten_tmp = new TenT();
+  mps(target_site) = new TenT();
+  if(dir=='r'){
+    size_t next_site = target_site+1;
+    Contract(eff_ham[0], gs_vec, {{0}, {0}}, ten_tmp);
+    InplaceContract(ten_tmp, eff_ham[1], {{0, 2}, {0, 1}});
+    ten_tmp->Transpose({0, 2, 1, 3});
+    TenT expanded_ten = FuseIndex( *ten_tmp, 2, 3);
+    expanded_ten = noise*expanded_ten;;
+    Expand(gs_vec, &expanded_ten, {2},  mps(target_site));
+
+    auto expanded_index = InverseIndex(expanded_ten.GetIndexes()[2]);
+    TenT expanded_zero_ten = TenT({expanded_index, mps[next_site].GetIndexes()[1],mps[next_site].GetIndexes()[2]});
+    Expand(mps(next_site), &expanded_zero_ten, {0}, ten_tmp);
+    mps(next_site) = ten_tmp;
+  }else if(dir=='l'){
+    size_t next_site = target_site-1;
+    Contract(gs_vec,eff_ham[2],{{2},{0}}, ten_tmp);
+    InplaceContract(ten_tmp, eff_ham[1],{{1,2},{1,3}});
+    ten_tmp->Transpose({0,2,3,1});
+    TenT expanded_ten = FuseIndex(*ten_tmp, 0, 1);
+    expanded_ten = noise*expanded_ten;
+    Expand(gs_vec, &expanded_ten, {0}, mps(target_site));
+
+    auto expanded_index = InverseIndex(expanded_ten.GetIndexes()[0]);
+    TenT expanded_zero_ten = TenT({mps[next_site].GetIndexes()[0],mps[next_site].GetIndexes()[1], expanded_index});
+    Expand(mps(next_site), &expanded_zero_ten, {2}, ten_tmp);
+    mps(next_site) = ten_tmp;
+  }
+//The expanded tensors are saved in mps
+}
+
+
+template <typename TenElemT, typename QNT>
+void LoadRelatedTensSingleSiteAlg(
+    FiniteMPS<TenElemT, QNT> &mps,
+    TenVec<GQTensor<TenElemT, QNT>> &lenvs,
+    TenVec<GQTensor<TenElemT, QNT>> &renvs,
+    const size_t target_site,
+    const char dir,
+    const SweepParams &sweep_params
+) {
+  auto N = mps.size();
+  switch (dir) {
+    case 'r':
+      if (target_site == 0) {
+        mps.LoadTen(
+            target_site+1,
+            GenMPSTenName(sweep_params.mps_path, target_site+1)
+        );
+        auto renv_len = N - target_site -1;
+        auto renv_file = GenEnvTenName("r", renv_len, sweep_params.temp_path);
+        renvs.LoadTen(renv_len, renv_file);
+        RemoveFile(renv_file);
+        auto lenv_len = 0;
+        auto lenv_file = GenEnvTenName("l", lenv_len, sweep_params.temp_path);
+        lenvs.LoadTen(lenv_len, lenv_file);
+      } else {
+        mps.LoadTen(
+            target_site + 1,
+            GenMPSTenName(sweep_params.mps_path, target_site + 1)
+        );
+        auto renv_len = N - target_site - 1;
+        auto renv_file = GenEnvTenName("r", renv_len, sweep_params.temp_path);
+        renvs.LoadTen(renv_len, renv_file);
+        RemoveFile(renv_file);
+      }
+      break;
+    case 'l':
+      if (target_site == N-1) {
+        mps.LoadTen(
+            target_site -1,
+            GenMPSTenName(sweep_params.mps_path, target_site-1)
+        );
+        auto renv_len = 0;
+        auto renv_file = GenEnvTenName("r", renv_len, sweep_params.temp_path);
+        renvs.LoadTen(renv_len, renv_file);
+
+        auto lenv_len = N-1;
+        auto lenv_file = GenEnvTenName("l", lenv_len, sweep_params.temp_path);
+        RemoveFile(lenv_file);
+      } else {
+        mps.LoadTen(
+            target_site - 1,
+            GenMPSTenName(sweep_params.mps_path, target_site - 1)
+        );
+        auto lenv_len = target_site;
+        auto lenv_file = GenEnvTenName("l", lenv_len, sweep_params.temp_path);
+        lenvs.LoadTen(lenv_len, lenv_file);
+        RemoveFile(lenv_file);
+      }
+      break;
+    default:
+      assert(false);
+  }
+}
+
+
+template <typename TenElemT, typename QNT>
+void DumpRelatedTensSingleSiteAlg(
+    FiniteMPS<TenElemT, QNT> &mps,
+    TenVec<GQTensor<TenElemT, QNT>> &lenvs,
+    TenVec<GQTensor<TenElemT, QNT>> &renvs,
+    const size_t target_site,
+    const char dir,
+    const SweepParams &sweep_params
+) {
+  auto N = mps.size();
+  lenvs.dealloc(target_site);
+  renvs.dealloc(N - target_site -1);
+  mps.DumpTen(
+      target_site,
+      GenMPSTenName(sweep_params.mps_path, target_site),
+      true);
+  switch (dir) {
+    case 'r':{
+      lenvs.DumpTen(
+          target_site + 1,
+          GenEnvTenName("l", target_site + 1, sweep_params.temp_path));
+    }break;
+    case 'l':{
+      auto next_renv_len = N - target_site;
+      renvs.DumpTen(
+          next_renv_len,
+          GenEnvTenName("r", next_renv_len, sweep_params.temp_path));
+    }break;
+    default:
+      assert(false);
+  }
+}
+
+template <typename TenElemT, typename QNT>
+double CalEnergyEptSingleSite(
+    FiniteMPS<TenElemT, QNT> &mps,
+    const MPO<GQTensor<TenElemT, QNT>> &mpo,
+    TenVec<GQTensor<TenElemT, QNT>> &lenvs,
+    TenVec<GQTensor<TenElemT, QNT>> &renvs,
+    const size_t target_site
+){
+  using TenT = GQTensor<TenElemT, QNT>;
+  std::vector<TenT *>eff_ham(3);
+  unsigned lenv_len = target_site;
+  unsigned renv_len = mps.size() - target_site - 1;
+  eff_ham[0] = lenvs(lenv_len);
+  // Safe const casts for MPO local tensors.
+  eff_ham[1] = const_cast<TenT *>(&mpo[target_site]);
+  eff_ham[2] = renvs(renv_len);
+  TenT *h_mul_state = eff_ham_mul_single_site_state(eff_ham, mps(target_site));
+  TenT scalar_ten;
+  TenT mps_ten_dag = Dag(mps[target_site]);
+  Contract(h_mul_state, &mps_ten_dag,{{0,1,2},{0,1,2}}, &scalar_ten);
+  delete h_mul_state;
+  double energy = Real(scalar_ten());
+  return energy;
+}
+
+}
+
+#endif //GRACEQ_MPS2_ONE_SITE_UPDATE_FINITE_VMPS_IMPL_H

--- a/include/gqmps2/algorithm/vmps/single_site_update_finite_vmps_impl.h
+++ b/include/gqmps2/algorithm/vmps/single_site_update_finite_vmps_impl.h
@@ -446,6 +446,7 @@ void SingleSiteFiniteVMPSExpand(
                                  mps[next_site].GetIndexes()[2]
                              });
     Expand(mps(next_site), &expanded_zero_ten, {0}, ten_tmp);
+    delete mps(next_site);
     mps(next_site) = ten_tmp;
   } else if (dir=='l') {
     size_t next_site = target_site - 1;
@@ -463,6 +464,7 @@ void SingleSiteFiniteVMPSExpand(
                                  expanded_index
                              });
     Expand(mps(next_site), &expanded_zero_ten, {2}, ten_tmp);
+    delete mps(next_site);
     mps(next_site) = ten_tmp;
   }
 }

--- a/include/gqmps2/algorithm/vmps/single_site_update_finite_vmps_impl.h
+++ b/include/gqmps2/algorithm/vmps/single_site_update_finite_vmps_impl.h
@@ -41,7 +41,7 @@ namespace gqmps2 {
   inline double MeasureEE(const DTenT &s, const size_t sdim);
 
   /** Fuse two indices of a tensor t. we suppose i<j, and the new index is placed on position i.
-   * Original index after index i a placed in original order.
+   * Original index after index i are placed in original order.
    */
   template <typename TenElemType, typename QNT>
   GQTensor<TenElemType, QNT> FuseIndex(const GQTensor<TenElemType, QNT>& t, unsigned int i, unsigned int j){
@@ -254,7 +254,7 @@ auto lancz_elapsed_time = lancz_timer.Elapsed();
     need_expand= false;
   }
 #ifdef GQMPS2_TIMING_MODE
-  auto expand_timer("single_site_fvmps_expand");
+  Timer expand_timer("single_site_fvmps_expand");
 #endif
   if(need_expand){
     SingleSiteFiniteVMPSExpand( lancz_res.gs_vec, mps, eff_ham, dir, target_site, noise);
@@ -264,7 +264,7 @@ auto lancz_elapsed_time = lancz_timer.Elapsed();
   }
 
 #ifdef GQMPS2_TIMING_MODE
-    auto expand_elapsed_time = expand_timer.PrintElapsed();
+    expand_timer.PrintElapsed();
 #endif
 #ifdef GQMPS2_TIMING_MODE
     Timer svd_timer("single_site_fvmps_svd");

--- a/include/gqmps2/algorithm/vmps/single_site_update_finite_vmps_impl.h
+++ b/include/gqmps2/algorithm/vmps/single_site_update_finite_vmps_impl.h
@@ -1,9 +1,19 @@
-//
-// Created by Hao-Xin on 2021/6/12.
-//
+// SPDX-License-Identifier: LGPL-3.0-only
+/*
+* Author: Hao-Xin Wang
+*         Rongyang Sun <sun-rongyang@outlook.com>
+* Creation Date: 2021-6-12
+*
+* Description: GraceQ/MPS2 project. Implementation details for single-site algorithm.
+*/
 
-#ifndef GRACEQ_MPS2_ONE_SITE_UPDATE_FINITE_VMPS_IMPL_H
-#define GRACEQ_MPS2_ONE_SITE_UPDATE_FINITE_VMPS_IMPL_H
+/**
+@file single_site_update_finite_vmps_impl.h
+@brief Implementation details for single-site finite variational MPS algorithm.
+*/
+
+#ifndef GQMPS2_ALGORITM_VMPS_ONE_SITE_UPDATE_FINITE_VMPS_IMPL_H
+#define GQMPS2_ALGORITM_VMPS_ONE_SITE_UPDATE_FINITE_VMPS_IMPL_H
 
 #include "gqmps2/algorithm/vmps/two_site_update_finite_vmps.h"    // SweepParams
 #include "gqmps2/one_dim_tn/mpo/mpo.h"                            // MPO
@@ -31,42 +41,54 @@ namespace gqmps2 {
   using std::endl;
   using std::vector;
 
-  const double max_noise = 1.0; //maximal noise
-  const double noise_increase = 1.02;
-  const double noise_decrease = 0.95;
-  const double alpha = 0.3;
+  const double kMaxNoise = 1.0; //maximal noise
+  const double kNoiseIncrease = 1.02;
+  const double kNoiseDecrease = 0.95;
+  const double kAlpha = 0.3;
 
   // Helpers
   template <typename DTenT>
   inline double MeasureEE(const DTenT &s, const size_t sdim);
 
+  // TODO: Need improve!
   /** Fuse two indices of a tensor t. we suppose i<j, and the new index is placed on position i.
-   * Original index after index i are placed in original order.
-   */
-  template <typename TenElemType, typename QNT>
-  GQTensor<TenElemType, QNT> FuseIndex(const GQTensor<TenElemType, QNT>& t, unsigned int i, unsigned int j){
+      Original index after index i are placed in original order.
+  */
+  template <typename TenElemT, typename QNT>
+  GQTensor<TenElemT, QNT> FuseIndex(
+      const GQTensor<TenElemT, QNT>& t,
+      size_t i, size_t j
+  ) {
     assert(i<j);
     assert(i<t.Rank() && j<t.Rank());
     assert(t.GetIndexes()[i].GetDir()==t.GetIndexes()[j].GetDir());
     Index<QNT> index1 = t.GetIndexes()[i];
     Index<QNT> index2 = t.GetIndexes()[j];
 
-    GQTensor<TenElemType, QNT> combiner = IndexCombine<TenElemType>(
-        InverseIndex(index1),InverseIndex(index2), index1.GetDir());
-    GQTensor<TenElemType, QNT> fused_tensor;
-    Contract(&t, &combiner, {{i,j}, {0,1}}, &fused_tensor);
-    unsigned int rank = fused_tensor.Rank();
-    std::vector<size_t> axs(rank);
-    for(size_t k=0;k<rank;k++){
-      if(k<i) axs[k]=k;
-      else if(k==i) axs[k]=rank-1;
-      else axs[k]=k-1;
+    GQTensor<TenElemT, QNT> combiner = IndexCombine<TenElemT>(
+                                           InverseIndex(index1),
+                                           InverseIndex(index2),
+                                           index1.GetDir()
+                                       );
+    GQTensor<TenElemT, QNT> fused_tensor;
+    Contract(&t, &combiner, {{i, j}, {0, 1}}, &fused_tensor);
+    size_t fused_ten_rank = fused_tensor.Rank();
+    std::vector<size_t> axs(fused_ten_rank);
+    for (size_t k = 0; k < fused_ten_rank; k++) {
+      if (k < i) {
+        axs[k] = k;
+      } else if (k == i) {
+        axs[k] = fused_ten_rank - 1;
+      } else {
+        axs[k] = k - 1;
+      }
     }
     fused_tensor.Transpose(axs);
     return fused_tensor;
   }
 
-  /**
+
+/**
 Function to perform single-site update finite vMPS algorithm.
 
 @note The input MPS will be considered an empty one.
@@ -76,26 +98,27 @@ template <typename TenElemT, typename QNT>
 GQTEN_Double SingleSiteFiniteVMPS(
     FiniteMPS<TenElemT, QNT> &mps,
     const MPO<GQTensor<TenElemT, QNT>> &mpo,
-    SweepParams &sweep_params){
+    SweepParams &sweep_params
+){
     assert(mps.size() == mpo.size());
 
-    std::cout << "\n";
-    std::cout << "=====> Sweep Parameter <=====" << "\n";
-    std::cout << "MPS/MPO size: \t " << mpo.size() << "\n";
-    std::cout << "The number of sweep times: \t " << sweep_params.sweeps << "\n";
-    std::cout << "Bond dimension: \t " << sweep_params.Dmin << "/" << sweep_params.Dmax << "\n";
-    std::cout << "Cut off truncation error: \t " <<sweep_params.trunc_err <<"\n";
-    std::cout << "Lanczos max iterations \t" <<sweep_params.lancz_params.max_iterations << "\n";
+    std::cout << std::endl;
+    std::cout << "=====> Sweep Parameter <=====" << std::endl;
+    std::cout << "MPS/MPO size: \t " << mpo.size() << std::endl;
+    std::cout << "The number of sweep times: \t " << sweep_params.sweeps << std::endl;
+    std::cout << "Bond dimension: \t " << sweep_params.Dmin << "/" << sweep_params.Dmax << std::endl;
+    std::cout << "Cut off truncation error: \t " <<sweep_params.trunc_err << std::endl;
+    std::cout << "Lanczos max iterations \t" <<sweep_params.lancz_params.max_iterations << std::endl;
     std::cout << "Preseted noises: \t[";
-    for(size_t i = 0; i < sweep_params.noises.size() ; i++){
+    for(size_t i = 0; i < sweep_params.noises.size(); i++){
       std::cout << sweep_params.noises[i];
-      if(i!=sweep_params.noises.size()-1){
-        std::cout << ", " ;
-      }else{
-        std::cout << "]\n";
+      if (i!=sweep_params.noises.size()-1) {
+        std::cout << ", ";
+      } else {
+        std::cout << "]" << std::endl;
       }
     }
-    std::cout << "MPS path: \t" << sweep_params.mps_path <<"\n";
+    std::cout << "MPS path: \t" << sweep_params.mps_path << std::endl;
     std::cout << "Temp path: \t" << sweep_params.temp_path << std::endl;
 
     // If the runtime temporary directory does not exit, create it and initialize
@@ -104,39 +127,44 @@ GQTEN_Double SingleSiteFiniteVMPS(
       CreatPath(sweep_params.temp_path);
       InitEnvs(mps, mpo, sweep_params, 1);
       std::cout << "no exsiting path " <<sweep_params.temp_path
-        <<", thus progress created it and generated environment tensors."
-        <<std::endl;
-    }else{
+                << ", thus progress created it and generated environment tensors."
+                << std::endl;
+    } else {
       std::cout << "finded exsiting path "<<sweep_params.temp_path
-        <<", thus progress will use the present environment tensors."
-        <<std::endl;
+                << ", thus progress will use the present environment tensors."
+                << std::endl;
     }
 
     GQTEN_Double e0;
 
-    if(sweep_params.noises.size()==0) sweep_params.noises.push_back(0.0);
+    if (sweep_params.noises.size() == 0) { sweep_params.noises.push_back(0.0); }
     double noise_start;
-    mps.LoadTen(0,GenMPSTenName(sweep_params.mps_path, 0));
+    mps.LoadTen(0, GenMPSTenName(sweep_params.mps_path, 0));
     for (size_t sweep = 1; sweep <= sweep_params.sweeps; ++sweep) {
-      if(sweep-1 < sweep_params.noises.size()){
+      if ((sweep - 1) < sweep_params.noises.size()) {
         noise_start = sweep_params.noises[sweep-1];
       }
       std::cout << "sweep " << sweep << std::endl;
       Timer sweep_timer("sweep");
       e0 = SingleSiteFiniteVMPSSweep(mps, mpo, sweep_params, noise_start);
       sweep_timer.PrintElapsed();
-      std::cout << "\n";
+      std::cout << std::endl;
     }
-    mps.DumpTen(0,GenMPSTenName(sweep_params.mps_path, 0),true);
+    mps.DumpTen(0, GenMPSTenName(sweep_params.mps_path, 0), true);
     return e0;
 }
 
+
+/**
+Single-site update DMRG algorithm refer to 10.1103/PhysRevB.91.155115
+*/
 template <typename TenElemT, typename QNT>
 double SingleSiteFiniteVMPSSweep(
     FiniteMPS<TenElemT, QNT> &mps,
     const MPO<GQTensor<TenElemT, QNT>> &mpo,
     const SweepParams &sweep_params,
-    double& noise_start) {
+    double& noise_start
+) {
   auto N = mps.size();
   using TenT = GQTensor<TenElemT, QNT>;
   TenVec<TenT> lenvs(N), renvs(N);
@@ -144,52 +172,65 @@ double SingleSiteFiniteVMPSSweep(
 
   double& noise_running = noise_start;
   for (size_t i = 0; i < N - 1; ++i) {
-    LoadRelatedTensSingleSiteAlg(mps, lenvs, renvs, i, 'r', sweep_params);
-// note: here we need mps[i](do not need load), mps[i+1], lenvs[i](do not need load), and mps[i]'s renvs
-// mps[i]'s renvs can be removed
-
+    LoadRelatedTensSingleSiteAlg(mps, lenvs, renvs, i, 'r', sweep_params);    // note: here we need mps[i](do not need load),
+                                                                              // mps[i+1], lenvs[i](do not need load), and mps[i]'s renvs
+                                                                              // mps[i]'s renvs can be removed
     actual_e0 = CalEnergyEptSingleSite(mps, mpo,lenvs, renvs, i);
-    if(actual_e0-e0 <= 0.0){
-      //expand and truncate let the energy lower or not change
+    if ((actual_e0 - e0) <= 0.0) {
+      // expand and truncate let the energy lower or not change
       // this case is very rare, but include the boundary mps tensor case
       // so we do nothing now
-    }else if(actual_e0-e0 >= alpha*fabs(actual_laststep_e0-e0)){
-      //below two case suppose actual_laststep_e0-laststep_e0>0, usually it is right
-      noise_running = noise_running*noise_decrease;
-    }else{
-      noise_running = std::min(noise_running*noise_increase, max_noise);
+    } else if ((actual_e0 - e0) >= kAlpha*fabs(actual_laststep_e0-e0)) {
+      // below two case suppose actual_laststep_e0-laststep_e0>0, usually it is right
+      noise_running = noise_running*kNoiseDecrease;
+    } else {
+      noise_running = std::min(noise_running*kNoiseIncrease, kMaxNoise);
     }
-    e0 = SingleSiteFiniteVMPSUpdate(mps, lenvs, renvs, mpo, sweep_params, 'r', i, noise_running);
+    e0 = SingleSiteFiniteVMPSUpdate(
+             mps,
+             lenvs, renvs,
+             mpo,
+             sweep_params, 'r', i,
+             noise_running
+         );
     actual_laststep_e0 = actual_e0;
-    DumpRelatedTensSingleSiteAlg(mps, lenvs, renvs, i, 'r', sweep_params);
-// note: here we need dump mps[i](free memory), lenvs[i+1](without free memory)
+    DumpRelatedTensSingleSiteAlg(mps, lenvs, renvs, i, 'r', sweep_params);    // note: here we need dump mps[i](free memory),
+                                                                              // lenvs[i+1](without free memory)
   }
+
   for (size_t i = N-1; i > 0; --i) {
     LoadRelatedTensSingleSiteAlg(mps, lenvs, renvs, i, 'l', sweep_params);
     actual_e0 = CalEnergyEptSingleSite(mps, mpo,lenvs, renvs, i);
-    if(actual_e0-e0 <= 0.0){
-    }else if(actual_e0-e0 >= alpha*fabs(actual_laststep_e0-e0)){
-      noise_running = noise_running*noise_decrease;
-    }else{
-      noise_running = std::min(noise_running*noise_increase, max_noise);
+    if ((actual_e0 - e0) <= 0.0) {
+    } else if ((actual_e0 - e0) >= kAlpha*fabs(actual_laststep_e0 - e0)) {
+      noise_running = noise_running * kNoiseDecrease;
+    } else {
+      noise_running = std::min(noise_running * kNoiseIncrease, kMaxNoise);
     }
-    e0 = SingleSiteFiniteVMPSUpdate(mps, lenvs, renvs, mpo, sweep_params, 'l', i, noise_running);
+    e0 = SingleSiteFiniteVMPSUpdate(
+             mps,
+             lenvs, renvs,
+             mpo,
+             sweep_params, 'l', i,
+             noise_running
+         );
     actual_laststep_e0 = actual_e0;
     DumpRelatedTensSingleSiteAlg(mps, lenvs, renvs, i, 'l', sweep_params);
   }
   return e0;
 }
 
+
 /**  Single step for single site update.
- *  This function includes below procedure:
- *    ** update \f$ mps[target] \f$ tensors according corresponding environment tensors and the mpo tensor,
- *       using lanczos algorithm;
- *    ** expand \f$ mps[target] \f$ and \f$ mps[next_site] \f$ by noise, if need
- *    ** canonicalize mps to \f$ mps[next_site] \f$ by svd, while truncate tensor \f$ mps[target] \f$ if need
- *    ** generate the next environment in the direction.
- *  When using this function, one must make sure memory at least contains \f$ mps[target] \f$ tensor,
- *  its environment tensors and \f$ mps[next_site] \f$.
- */
+This function includes below procedure:
+- update `mps[target]` tensors according corresponding environment tensors and the mpo tensor, using lanczos algorithm;
+- expand `mps[target]` and `mps[next_site]` by noise, if need;
+- canonicalize mps to `mps[next_site]` by SVD, while truncate tensor `mps[target]` if need;
+- generate the next environment in the direction.
+
+When using this function, one must make sure memory at least contains `mps[target]` tensor,
+its environment tensors and `mps[next_site]`.
+*/
 template <typename TenElemT, typename QNT>
 double SingleSiteFiniteVMPSUpdate(
     FiniteMPS<TenElemT, QNT> &mps,
@@ -199,26 +240,27 @@ double SingleSiteFiniteVMPSUpdate(
     const SweepParams &sweep_params,
     const char dir,
     const size_t target_site,
-    double noise
-  ){
+    const double preset_noise
+) {
   Timer update_timer("single_site_fvmps_update");
 
 #ifdef GQMPS2_TIMING_MODE
   Timer preprocessing_timer("single_site_fvmps_preprocessing");
 #endif
+  double noise = preset_noise;
   auto N = mps.size();
-  unsigned lenv_len = target_site;
-  unsigned renv_len = N - target_site - 1;
-  unsigned svd_ldims;
-  unsigned next_site;
+  size_t lenv_len = target_site;
+  size_t renv_len = N - target_site - 1;
+  size_t svd_ldims;
+  size_t next_site;
   switch (dir) {
     case 'r':
-      svd_ldims=2;
-      next_site=target_site+1;
+      svd_ldims = 2;
+      next_site = target_site + 1;
       break;
     case 'l':
-      svd_ldims=1;
-      next_site=target_site-1;
+      svd_ldims = 1;
+      next_site = target_site - 1;
       break;
     default:
       std::cout << "dir must be 'r' or 'l', but " << dir << std::endl;
@@ -226,180 +268,203 @@ double SingleSiteFiniteVMPSUpdate(
   }
 
   using TenT = GQTensor<TenElemT, QNT>;
-  std::vector<TenT *>eff_ham(3);
+  std::vector<TenT *> eff_ham(3);
   eff_ham[0] = lenvs(lenv_len);
-  // Safe const casts for MPO local tensors.
-  eff_ham[1] = const_cast<TenT *>(&mpo[target_site]);
+  eff_ham[1] = const_cast<TenT *>(mpo(target_site));    // Safe const casts for MPO local tensors.
   eff_ham[2] = renvs(renv_len);
 
-  std::vector<size_t> mps_ten_shape = mps[target_site].GetShape();
+  auto mps_ten_shape = mps[target_site].GetShape();
   Timer lancz_timer("single_site_fvmps_lancz");
   auto lancz_res = LanczosSolver(
-      eff_ham, mps(target_site),
-      &eff_ham_mul_single_site_state,
-      sweep_params.lancz_params);//note here mps(target_site) are destroyed.
+                       eff_ham,
+                       mps(target_site),
+                       &eff_ham_mul_single_site_state,
+                       sweep_params.lancz_params
+                   );                                   //note here mps(target_site) are destroyed.
 #ifdef GQMPS2_TIMING_MODE
-auto lancz_elapsed_time = lancz_timer.PrintElapsed();
+  auto lancz_elapsed_time = lancz_timer.PrintElapsed();
 #else
-auto lancz_elapsed_time = lancz_timer.Elapsed();
+  auto lancz_elapsed_time = lancz_timer.Elapsed();
 #endif
-  bool need_expand(true);
 
-  if(fabs(noise)<1e-15){need_expand=false;}
-  else if(
-      (target_site < N/2 && mps_ten_shape[0]*mps_ten_shape[1]<=mps_ten_shape[2]) ||
-      (target_site > N/2 && mps_ten_shape[2]*mps_ten_shape[1]<=mps_ten_shape[0])
-      ){
-    noise = 0.0; //just for output
-    need_expand= false;
-  }
 #ifdef GQMPS2_TIMING_MODE
   Timer expand_timer("single_site_fvmps_expand");
 #endif
-  if(need_expand){
-    SingleSiteFiniteVMPSExpand( lancz_res.gs_vec, mps, eff_ham, dir, target_site, noise);
+
+  bool need_expand(true);
+  if (fabs(noise) < 1e-15) {
+    need_expand = false;
+  } else if (
+      (target_site < N/2 && mps_ten_shape[0]*mps_ten_shape[1]<=mps_ten_shape[2]) ||
+      (target_site > N/2 && mps_ten_shape[2]*mps_ten_shape[1]<=mps_ten_shape[0])
+  ) {
+    noise = 0.0;            //just for output
+    need_expand= false;
+  }
+  if (need_expand) {
+    SingleSiteFiniteVMPSExpand(
+        mps,
+        lancz_res.gs_vec,
+        eff_ham,
+        dir,
+        target_site,
+        noise
+    );
     delete lancz_res.gs_vec;
-  }else{
+  } else {
     mps(target_site) = lancz_res.gs_vec;
   }
 
 #ifdef GQMPS2_TIMING_MODE
-    expand_timer.PrintElapsed();
+  expand_timer.PrintElapsed();
 #endif
-#ifdef GQMPS2_TIMING_MODE
-    Timer svd_timer("single_site_fvmps_svd");
-#endif
-
-    TenT u, vt;
-    GQTensor<GQTEN_Double, QNT> s;
-    GQTEN_Double actual_trunc_err;
-    size_t D;
-    QNT zero_div = Div(mps[target_site])-Div(mps[target_site]);
-    QNT div_left = (dir=='r'? Div(mps[target_site]): zero_div );
-    SVD(
-        mps(target_site),
-        svd_ldims, div_left,
-        sweep_params.trunc_err, sweep_params.Dmin, sweep_params.Dmax,
-        &u, &s, &vt, &actual_trunc_err, &D
-    );
-    auto ee = MeasureEE(s, D);
 
 #ifdef GQMPS2_TIMING_MODE
-    svd_timer.PrintElapsed();
+  Timer svd_timer("single_site_fvmps_svd");
+#endif
+
+  TenT u, vt;
+  GQTensor<GQTEN_Double, QNT> s;
+  GQTEN_Double actual_trunc_err;
+  size_t D;
+  auto zero_div = Div(mps[target_site]) - Div(mps[target_site]);
+  auto div_left = (dir=='r' ? Div(mps[target_site]) : zero_div);
+  SVD(
+      mps(target_site),
+      svd_ldims, div_left,
+      sweep_params.trunc_err, sweep_params.Dmin, sweep_params.Dmax,
+      &u, &s, &vt, &actual_trunc_err, &D
+  );
+  auto ee = MeasureEE(s, D);
+
+#ifdef GQMPS2_TIMING_MODE
+  svd_timer.PrintElapsed();
 #endif
 
 
 #ifdef GQMPS2_TIMING_MODE
-    Timer update_mps_ten_timer("single_site_fvmps_update_mps_ten");
+  Timer update_mps_ten_timer("single_site_fvmps_update_mps_ten");
 #endif
-    TenT* temp_ten1 = new TenT();
-    TenT* temp_ten2 = new TenT();
+
+  TenT* temp_ten1 = new TenT();
+  TenT* temp_ten2 = new TenT();
   switch(dir){
     case 'r':
       mps[target_site] = std::move(u);
       Contract(&s, &vt, {{1}, {0}}, temp_ten1);
-      Contract(temp_ten1, mps(next_site), {{1},{0}},temp_ten2);
-      delete temp_ten1; delete mps(next_site);
-      mps(next_site)= temp_ten2;
+      Contract(temp_ten1, mps(next_site), {{1}, {0}}, temp_ten2);
+      delete temp_ten1;
+      delete mps(next_site);
+      mps(next_site) = temp_ten2;
       break;
     case 'l':
       mps[target_site] = std::move(vt);
       Contract(&u, &s, {{1}, {0}}, temp_ten1);
       Contract(mps(next_site), temp_ten1, {{2}, {0}}, temp_ten2);
-      delete temp_ten1; delete mps(next_site);
-      mps(next_site) =temp_ten2;
+      delete temp_ten1;
+      delete mps(next_site);
+      mps(next_site) = temp_ten2;
       break;
   }
 
-
 #ifdef GQMPS2_TIMING_MODE
-    update_mps_ten_timer.PrintElapsed();
+  update_mps_ten_timer.PrintElapsed();
 #endif
 
-    // Update environment tensors
+// Update environment tensors
 #ifdef GQMPS2_TIMING_MODE
-    Timer update_env_ten_timer("single_site_fvmps_update_env_ten");
+  Timer update_env_ten_timer("single_site_fvmps_update_env_ten");
 #endif
-    switch (dir) {
-      case 'r':{
-        TenT temp1, temp2, lenv_ten;
-        Contract(&lenvs[lenv_len], &mps[target_site], {{0}, {0}}, &temp1);
-        Contract(&temp1, &mpo[target_site], {{0, 2}, {0, 1}}, &temp2);
-        auto mps_ten_dag = Dag(mps[target_site]);
-        Contract(&temp2, &mps_ten_dag, {{0 ,2}, {0, 1}}, &lenv_ten);
-        lenvs[lenv_len + 1] = std::move(lenv_ten);
-      }break;
-      case 'l':{
-        TenT temp1, temp2, renv_ten;
-        Contract(&mps[target_site], eff_ham[2], {{2}, {0}}, &temp1);
-        Contract(&temp1, &mpo[target_site], {{1, 2}, {1, 3}}, &temp2);
-        auto mps_ten_dag = Dag(mps[target_site]);
-        Contract(&temp2, &mps_ten_dag, {{3, 1}, {1, 2}}, &renv_ten);
-        renvs[renv_len + 1] = std::move(renv_ten);
-      }break;
-      default:
-        assert(false);
-    }
+
+  switch (dir) {
+    case 'r':{
+      TenT temp1, temp2, lenv_ten;
+      Contract(&lenvs[lenv_len], &mps[target_site], {{0}, {0}}, &temp1);
+      Contract(&temp1, &mpo[target_site], {{0, 2}, {0, 1}}, &temp2);
+      auto mps_ten_dag = Dag(mps[target_site]);
+      Contract(&temp2, &mps_ten_dag, {{0 ,2}, {0, 1}}, &lenv_ten);
+      lenvs[lenv_len + 1] = std::move(lenv_ten);
+    }break;
+    case 'l':{
+      TenT temp1, temp2, renv_ten;
+      Contract(&mps[target_site], eff_ham[2], {{2}, {0}}, &temp1);
+      Contract(&temp1, &mpo[target_site], {{1, 2}, {1, 3}}, &temp2);
+      auto mps_ten_dag = Dag(mps[target_site]);
+      Contract(&temp2, &mps_ten_dag, {{3, 1}, {1, 2}}, &renv_ten);
+      renvs[renv_len + 1] = std::move(renv_ten);
+    }break;
+    default:
+      assert(false);
+  }
+
 #ifdef GQMPS2_TIMING_MODE
-    update_env_ten_timer.PrintElapsed();
+  update_env_ten_timer.PrintElapsed();
 #endif
 
 
-    auto update_elapsed_time = update_timer.Elapsed();
-    std::cout << "Site " << std::setw(4) << target_site
-              << " E0 = " << std::setw(20) << std::setprecision(kLanczEnergyOutputPrecision) << std::fixed << lancz_res.gs_eng
-              << " noise = " <<  std::setprecision(2) << std::scientific  << noise << std::fixed
-              << " TruncErr = " << std::setprecision(2) << std::scientific << actual_trunc_err << std::fixed
-              << " D = " << std::setw(5) << D
-              << " Iter = " << std::setw(3) << lancz_res.iters
-              << " LanczT = " << std::setw(8) << lancz_elapsed_time
-              << " TotT = " << std::setw(8) << update_elapsed_time
-              << " S = " << std::setw(10) << std::setprecision(7) << ee;
-    std::cout << std::scientific << std::endl;
-    return lancz_res.gs_eng;
+  auto update_elapsed_time = update_timer.Elapsed();
+  std::cout << "Site " << std::setw(4) << target_site
+            << " E0 = " << std::setw(20) << std::setprecision(kLanczEnergyOutputPrecision) << std::fixed << lancz_res.gs_eng
+            << " noise = " <<  std::setprecision(2) << std::scientific  << noise << std::fixed
+            << " TruncErr = " << std::setprecision(2) << std::scientific << actual_trunc_err << std::fixed
+            << " D = " << std::setw(5) << D
+            << " Iter = " << std::setw(3) << lancz_res.iters
+            << " LanczT = " << std::setw(8) << lancz_elapsed_time
+            << " TotT = " << std::setw(8) << update_elapsed_time
+            << " S = " << std::setw(10) << std::setprecision(7) << ee;
+  std::cout << std::scientific << std::endl;
+  return lancz_res.gs_eng;
 }
+
 
 template <typename TenElemT, typename QNT>
 void SingleSiteFiniteVMPSExpand(
-    GQTensor<TenElemT, QNT>* gs_vec,
     FiniteMPS<TenElemT, QNT> &mps,
-    std::vector< GQTensor<TenElemT, QNT> *> eff_ham,
+    const GQTensor<TenElemT, QNT> *gs_vec,
+    const std::vector< GQTensor<TenElemT, QNT> *> &eff_ham,
     const char dir,
     const size_t target_site,
-    double noise
-    ){
-  // we suppose mps only contain mps[next_site]
+    const double noise
+) {
+  // note: The expanded tensors are saved in mps
   using TenT = GQTensor<TenElemT, QNT>;
   TenT* ten_tmp = new TenT();
-  mps(target_site) = new TenT();
-  if(dir=='r'){
-    size_t next_site = target_site+1;
+  mps(target_site) = new TenT();    // we suppose mps only contain mps[next_site]
+  if (dir=='r') {
+    size_t next_site = target_site + 1;
     Contract(eff_ham[0], gs_vec, {{0}, {0}}, ten_tmp);
     InplaceContract(ten_tmp, eff_ham[1], {{0, 2}, {0, 1}});
     ten_tmp->Transpose({0, 2, 1, 3});
-    TenT expanded_ten = FuseIndex( *ten_tmp, 2, 3);
-    expanded_ten = noise*expanded_ten;;
+    TenT expanded_ten = FuseIndex(*ten_tmp, 2, 3);
+    expanded_ten = noise * expanded_ten;;
     Expand(gs_vec, &expanded_ten, {2},  mps(target_site));
 
     auto expanded_index = InverseIndex(expanded_ten.GetIndexes()[2]);
-    TenT expanded_zero_ten = TenT({expanded_index, mps[next_site].GetIndexes()[1],mps[next_site].GetIndexes()[2]});
+    TenT expanded_zero_ten = TenT({
+                                 expanded_index,
+                                 mps[next_site].GetIndexes()[1],
+                                 mps[next_site].GetIndexes()[2]
+                             });
     Expand(mps(next_site), &expanded_zero_ten, {0}, ten_tmp);
     mps(next_site) = ten_tmp;
-  }else if(dir=='l'){
-    size_t next_site = target_site-1;
-    Contract(gs_vec,eff_ham[2],{{2},{0}}, ten_tmp);
-    InplaceContract(ten_tmp, eff_ham[1],{{1,2},{1,3}});
-    ten_tmp->Transpose({0,2,3,1});
+  } else if (dir=='l') {
+    size_t next_site = target_site - 1;
+    Contract(gs_vec, eff_ham[2], {{2}, {0}}, ten_tmp);
+    InplaceContract(ten_tmp, eff_ham[1], {{1, 2}, {1, 3}});
+    ten_tmp->Transpose({0, 2, 3, 1});
     TenT expanded_ten = FuseIndex(*ten_tmp, 0, 1);
     expanded_ten = noise*expanded_ten;
     Expand(gs_vec, &expanded_ten, {0}, mps(target_site));
 
     auto expanded_index = InverseIndex(expanded_ten.GetIndexes()[0]);
-    TenT expanded_zero_ten = TenT({mps[next_site].GetIndexes()[0],mps[next_site].GetIndexes()[1], expanded_index});
+    TenT expanded_zero_ten = TenT({
+                                 mps[next_site].GetIndexes()[0],
+                                 mps[next_site].GetIndexes()[1],
+                                 expanded_index
+                             });
     Expand(mps(next_site), &expanded_zero_ten, {2}, ten_tmp);
     mps(next_site) = ten_tmp;
   }
-//The expanded tensors are saved in mps
 }
 
 
@@ -420,7 +485,7 @@ void LoadRelatedTensSingleSiteAlg(
             target_site+1,
             GenMPSTenName(sweep_params.mps_path, target_site+1)
         );
-        auto renv_len = N - target_site -1;
+        auto renv_len = N - target_site - 1;
         auto renv_file = GenEnvTenName("r", renv_len, sweep_params.temp_path);
         renvs.LoadTen(renv_len, renv_file);
         RemoveFile(renv_file);
@@ -479,7 +544,7 @@ void DumpRelatedTensSingleSiteAlg(
 ) {
   auto N = mps.size();
   lenvs.dealloc(target_site);
-  renvs.dealloc(N - target_site -1);
+  renvs.dealloc(N - target_site - 1);
   mps.DumpTen(
       target_site,
       GenMPSTenName(sweep_params.mps_path, target_site),
@@ -501,6 +566,7 @@ void DumpRelatedTensSingleSiteAlg(
   }
 }
 
+
 template <typename TenElemT, typename QNT>
 double CalEnergyEptSingleSite(
     FiniteMPS<TenElemT, QNT> &mps,
@@ -508,11 +574,11 @@ double CalEnergyEptSingleSite(
     TenVec<GQTensor<TenElemT, QNT>> &lenvs,
     TenVec<GQTensor<TenElemT, QNT>> &renvs,
     const size_t target_site
-){
+) {
   using TenT = GQTensor<TenElemT, QNT>;
-  std::vector<TenT *>eff_ham(3);
-  unsigned lenv_len = target_site;
-  unsigned renv_len = mps.size() - target_site - 1;
+  std::vector<TenT *> eff_ham(3);
+  size_t lenv_len = target_site;
+  size_t renv_len = mps.size() - target_site - 1;
   eff_ham[0] = lenvs(lenv_len);
   // Safe const casts for MPO local tensors.
   eff_ham[1] = const_cast<TenT *>(&mpo[target_site]);
@@ -520,11 +586,10 @@ double CalEnergyEptSingleSite(
   TenT *h_mul_state = eff_ham_mul_single_site_state(eff_ham, mps(target_site));
   TenT scalar_ten;
   TenT mps_ten_dag = Dag(mps[target_site]);
-  Contract(h_mul_state, &mps_ten_dag,{{0,1,2},{0,1,2}}, &scalar_ten);
+  Contract(h_mul_state, &mps_ten_dag, {{0, 1, 2}, {0, 1, 2}}, &scalar_ten);
   delete h_mul_state;
   double energy = Real(scalar_ten());
   return energy;
 }
-}
-
-#endif //GRACEQ_MPS2_ONE_SITE_UPDATE_FINITE_VMPS_IMPL_H
+} /* gqmps2 */
+#endif //GQMPS2_ALGORITM_VMPS_ONE_SITE_UPDATE_FINITE_VMPS_IMPL_H

--- a/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps.h
+++ b/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps.h
@@ -29,7 +29,7 @@ struct SweepParams {
       const size_t sweeps,
       const size_t dmin, const size_t dmax, const double trunc_err,
       const LanczosParams &lancz_params,
-      const std::vector<double> noises = std::vector<double>(1,0.0),
+      const std::vector<double> noises = std::vector<double>(1, 0.0),
       const std::string mps_path = kMpsPath,
       const std::string temp_path = kRuntimeTempPath
   ) :

--- a/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps.h
+++ b/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps.h
@@ -29,6 +29,7 @@ struct SweepParams {
       const size_t sweeps,
       const size_t dmin, const size_t dmax, const double trunc_err,
       const LanczosParams &lancz_params,
+      const std::vector<double> noises = std::vector<double>(),
       const std::string mps_path = kMpsPath,
       const std::string temp_path = kRuntimeTempPath
   ) :
@@ -52,6 +53,9 @@ struct SweepParams {
 
   /// Runtime temporary files directory path
   std::string temp_path;
+
+  /// Noise magnitude each sweep
+  std::vector<double> noises;
 };
 } /* gqmps2 */
 

--- a/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps.h
+++ b/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps.h
@@ -29,7 +29,7 @@ struct SweepParams {
       const size_t sweeps,
       const size_t dmin, const size_t dmax, const double trunc_err,
       const LanczosParams &lancz_params,
-      const std::vector<double> noises = std::vector<double>(),
+      const std::vector<double> noises = std::vector<double>(1,0.0),
       const std::string mps_path = kMpsPath,
       const std::string temp_path = kRuntimeTempPath
   ) :

--- a/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps.h
+++ b/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps.h
@@ -36,6 +36,7 @@ struct SweepParams {
       sweeps(sweeps),
       Dmin(dmin), Dmax(dmax), trunc_err(trunc_err),
       lancz_params(lancz_params),
+      noises(noises),
       mps_path(mps_path),
       temp_path(temp_path) {}
 

--- a/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps_impl.h
+++ b/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps_impl.h
@@ -164,7 +164,7 @@ void InitEnvs(
 /**
 Function to perform a single two-site finite vMPS sweep.
 
-@note Before the sweep and after the sweep, the MPS is empty.
+@note Before the sweep and after the sweep, the MPS only contains mps[1].
 */
 template <typename TenElemT, typename QNT>
 double TwoSiteFiniteVMPSSweep(
@@ -218,13 +218,11 @@ double TwoSiteFiniteVMPSUpdate(
   // Assign some parameters
   auto N = mps.size();
   std::vector<std::vector<size_t>> init_state_ctrct_axes;
-  std::string where;
   size_t svd_ldims;
   size_t lsite_idx, rsite_idx;
   size_t lenv_len, renv_len;
   std::string lblock_file, rblock_file;
   init_state_ctrct_axes = {{2}, {0}};
-  where = "cent";
   svd_ldims = 2;
   switch (dir) {
     case 'r':
@@ -262,8 +260,8 @@ double TwoSiteFiniteVMPSUpdate(
   Timer lancz_timer("two_site_fvmps_lancz");
   auto lancz_res = LanczosSolver(
                        eff_ham, init_state,
-                       sweep_params.lancz_params,
-                       where
+                       &eff_ham_mul_two_site_state,
+                       sweep_params.lancz_params
                    );
 #ifdef GQMPS2_TIMING_MODE
   auto lancz_elapsed_time = lancz_timer.PrintElapsed();

--- a/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps_impl.h
+++ b/include/gqmps2/algorithm/vmps/two_site_update_finite_vmps_impl.h
@@ -75,6 +75,7 @@ inline void RemoveFile(const std::string &file) {
 Function to perform two-site update finite vMPS algorithm.
 
 @note The input MPS will be considered an empty one.
+@note The canonical center of MPS should be set at site 0 or 1.
 */
 template <typename TenElemT, typename QNT>
 GQTEN_Double TwoSiteFiniteVMPS(
@@ -199,6 +200,7 @@ double TwoSiteFiniteVMPSSweep(
  *       using lanczos algorithm;
  *    ** decompose and truncate mps[lsite_idx]*mps[rsite_idx] by svd decomposition. Canonical central are determined by the direction;
  *    ** generate the next environment in the direction.
+ *  When using this function, one must make sure memory at least contains mps[lsite_idx] and mps[rsite_idx] tensors, and their environment tensors.
  */
 template <typename TenElemT, typename QNT>
 double TwoSiteFiniteVMPSUpdate(

--- a/include/gqmps2/case_params_parser.h
+++ b/include/gqmps2/case_params_parser.h
@@ -99,7 +99,7 @@ public:
   /// Parse a std::vector<double> parameter.
   std::vector<double> ParseDoubleVec(
       const std:: string &item    ///< Parameter key.
-      ){
+  ) {
     return case_params_[item].get<std::vector<double>>();
   }
 private:

--- a/include/gqmps2/case_params_parser.h
+++ b/include/gqmps2/case_params_parser.h
@@ -96,7 +96,12 @@ public:
     return case_params_[item].get<bool>();
   }
 
-
+  /// Parse a std::vector<double> parameter.
+  std::vector<double> ParseDoubleVec(
+      const std:: string &item    ///< Parameter key.
+      ){
+    return case_params_[item].get<std::vector<double>>();
+  }
 private:
   json case_params_;
 };

--- a/include/gqmps2/gqmps2.h
+++ b/include/gqmps2/gqmps2.h
@@ -32,6 +32,7 @@
 // Algorithms
 #include "gqmps2/algorithm/lanczos_solver.h"                        // LanczosParams
 #include "gqmps2/algorithm/vmps/two_site_update_finite_vmps.h"      // TwoSiteFiniteVMPS, SweepParams
+#include "gqmps2/algorithm/vmps/single_site_update_finite_vmps_impl.h"   // SingleSiteFiniteVMPS
 
 
 #endif /* ifndef GQMPS2_GQMPS2_H */

--- a/include/gqmps2/one_dim_tn/mpo/mpogen/mpogen_impl.h
+++ b/include/gqmps2/one_dim_tn/mpo/mpogen/mpogen_impl.h
@@ -356,7 +356,10 @@ MPOGenerator<TenElemT, QNT>::HeadMpoTenRepr2MpoTen_(
     const IndexT &rvb,
     const TenElemVec &label_coef_mapping, const GQTensorVec &label_op_mapping
 ) {
-  auto mpo_ten = GQTensorT({pb_in_vector_.front(), rvb, pb_out_vector_.front()});
+  QNT qn_eg = rvb.GetQNSct(0).GetQn();
+  QNT qn0 = qn_eg - qn_eg;
+  IndexT lvb = IndexT({QNSctT(qn0, 1)}, GQTenIndexDirType::IN);
+  auto mpo_ten = GQTensorT({lvb, pb_in_vector_.front(), pb_out_vector_.front(), rvb});
   for (size_t y = 0; y < op_repr_mat.cols; ++y) {
     auto elem = op_repr_mat(0, y);
     if (elem != kNullOpRepr) {
@@ -374,7 +377,10 @@ MPOGenerator<TenElemT, QNT>::TailMpoTenRepr2MpoTen_(
     const SparOpReprMat &op_repr_mat,
     const IndexT &lvb,
     const TenElemVec &label_coef_mapping, const GQTensorVec &label_op_mapping) {
-  auto mpo_ten = GQTensorT({pb_in_vector_.back(), lvb, pb_out_vector_.back()});
+  QNT qn_eg = lvb.GetQNSct(0).GetQn();
+  QNT qn0 = qn_eg - qn_eg;
+  IndexT rvb = IndexT({QNSctT(qn0, 1)}, GQTenIndexDirType::OUT);
+  auto mpo_ten = GQTensorT({lvb, pb_in_vector_.back(), pb_out_vector_.back(), rvb});
   for (size_t x = 0; x < op_repr_mat.rows; ++x) {
     auto elem = op_repr_mat(x, 0);
     if (elem != kNullOpRepr) {
@@ -415,7 +421,7 @@ void AddOpToHeadMpoTen(TenT *pmpo_ten, const TenT &rop, const size_t rvb_coor) {
     for (size_t tpb_coor = 0; tpb_coor < rop.GetIndexes()[1].dim(); ++tpb_coor) {
       auto elem = rop.GetElem({bpb_coor, tpb_coor});
       if (elem != 0.0) {
-        (*pmpo_ten)(bpb_coor, rvb_coor, tpb_coor) = elem;
+        (*pmpo_ten)(0, bpb_coor, tpb_coor, rvb_coor) = elem;
       }
     }
   }
@@ -428,7 +434,7 @@ void AddOpToTailMpoTen(TenT *pmpo_ten, const TenT &rop, const size_t lvb_coor) {
     for (size_t tpb_coor = 0; tpb_coor < rop.GetIndexes()[1].dim(); ++tpb_coor) {
       auto elem = rop.GetElem({bpb_coor, tpb_coor});
       if (elem != 0.0) {
-        (*pmpo_ten)(bpb_coor, lvb_coor, tpb_coor) = elem;
+        (*pmpo_ten)(lvb_coor, bpb_coor, tpb_coor, 0) = elem;
       }
     }
   }

--- a/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps.h
+++ b/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps.h
@@ -219,7 +219,7 @@ void FiniteMPS<TenElemT, QNT>::RightCanonicalizeTen_(const size_t site_idx) {
 
   LocalTenT temp_ten;
   Contract(&u, &s, {{1}, {0}}, &temp_ten);
-  std::vector<std::vector<size_t>> ctrct_axes = {{2},{0}};
+  std::vector<std::vector<size_t>> ctrct_axes = {{2}, {0}};
   auto pprev_ten = new LocalTenT;
   Contract((*this)(site_idx - 1), &temp_ten, ctrct_axes, pprev_ten);
   delete (*this)(site_idx - 1);

--- a/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps.h
+++ b/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps.h
@@ -172,12 +172,7 @@ void FiniteMPS<TenElemT, QNT>::LeftCanonicalize_(const size_t stop_idx) {
 template <typename TenElemT, typename QNT>
 void FiniteMPS<TenElemT, QNT>::LeftCanonicalizeTen_(const size_t site_idx) {
   assert(site_idx < this->size() - 1);
-  size_t ldims;
-  if (site_idx == 0) {
-    ldims = 1;
-  } else {
-    ldims = 2;
-  }
+  size_t ldims(2);
   GQTensor<GQTEN_Double, QNT> s;
   LocalTenT vt;
   auto pu = new LocalTenT;
@@ -224,15 +219,7 @@ void FiniteMPS<TenElemT, QNT>::RightCanonicalizeTen_(const size_t site_idx) {
 
   LocalTenT temp_ten;
   Contract(&u, &s, {{1}, {0}}, &temp_ten);
-  std::vector<size_t> ta_ctrct_axes;
-  if ((site_idx - 1) == 0) {
-    ta_ctrct_axes = {1};
-  } else {
-    ta_ctrct_axes = {2};
-  }
-  std::vector<std::vector<size_t>> ctrct_axes;
-  ctrct_axes.emplace_back(ta_ctrct_axes);
-  ctrct_axes.push_back({0});
+  std::vector<std::vector<size_t>> ctrct_axes = {{2},{0}};
   auto pprev_ten = new LocalTenT;
   Contract((*this)(site_idx - 1), &temp_ten, ctrct_axes, pprev_ten);
   delete (*this)(site_idx - 1);
@@ -251,7 +238,8 @@ tensor generated from each SVD step will be normalized.
 
 @param mps To-be truncated finite MPS.
 @param trunc_err The target truncation error.
-@param Dmin The 
+@param Dmin Minimal bond dimension
+@param Dmax Maximal bond dimension
 */
 template <typename TenElemT, typename QNT>
 void TruncateMPS(
@@ -270,12 +258,7 @@ void TruncateMPS(
   GQTEN_Double actual_trunc_err;
   size_t D;
   for (size_t i = 0; i < mps_size - 1; ++i) {
-    size_t ldims;
-    if (i == 0) {
-      ldims = 1;
-    } else {
-      ldims = 2;
-    }
+    size_t ldims(2);
     GQTensor<GQTEN_Double, QNT> s;
     LocalTenT vt;
     auto pu = new LocalTenT;

--- a/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps_init.h
+++ b/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps_init.h
@@ -215,8 +215,7 @@ Initialize a finite MPS as a direct product state.
 template <typename TenElemT, typename QNT>
 void DirectStateInitMps(
     FiniteMPS<TenElemT, QNT> &mps,
-    const std::vector<size_t> &stat_labs,
-    const QNT &zero_div
+    const std::vector<size_t> &stat_labs
 ) {
   using TenT = GQTensor<TenElemT, QNT>;
   using IndexT = Index<QNT>;
@@ -237,25 +236,25 @@ void DirectStateInitMps(
 
   auto stat_lab = stat_labs[0];
   auto rvb_qn = div - pb_out_set[0].GetQNSctFromActualCoor(stat_lab).GetQn();
+  lvb = IndexT({QNSctT(div-div, 1)}, GQTenIndexDirType::IN);
   rvb = IndexT({QNSctT(rvb_qn, 1)}, GQTenIndexDirType::OUT);
-  mps(0) = new TenT({pb_out_set[0], rvb});
-  (mps[0])({stat_lab, 0}) = 1;
+  mps(0) = new TenT({lvb, pb_out_set[0], rvb});
+  (mps[0])({0, stat_lab, 0}) = 1;
 
   for (size_t i = 1; i < N-1; ++i) {
     lvb = InverseIndex(rvb);
     stat_lab = stat_labs[i];
-    rvb_qn = zero_div -
-             pb_out_set[i].GetQNSctFromActualCoor(stat_lab).GetQn() +
-             lvb.GetQNSctFromActualCoor(0).GetQn();
+    rvb_qn = lvb.GetQNSctFromActualCoor(0).GetQn() -pb_out_set[i].GetQNSctFromActualCoor(stat_lab).GetQn();
     rvb = IndexT({QNSctT(rvb_qn, 1)}, GQTenIndexDirType::OUT);
     mps(i) = new TenT({lvb, pb_out_set[i], rvb});
     (mps[i])({0, stat_lab, 0}) = 1;
   }
 
   lvb = InverseIndex(rvb);
-  mps(N-1) = new TenT({lvb, pb_out_set[N-1]});
+  rvb = IndexT({QNSctT(div-div, 1)}, GQTenIndexDirType::OUT);
+  mps(N-1) = new TenT({lvb, pb_out_set[N-1], rvb});
   stat_lab = stat_labs[N-1];
-  (mps[N-1])({0, stat_lab}) = 1;
+  (mps[N-1])({0, stat_lab, 0}) = 1;
 
   // Centralize MPS.
   mps.Centralize(0);
@@ -269,7 +268,6 @@ template <typename TenElemT, typename QNT>
 void ExtendDirectRandomInitMps(
     FiniteMPS<TenElemT, QNT> &mps,
     const std::vector<std::vector<size_t>> &stat_labs_set,
-    const QNT &zero_div,
     const size_t enlarged_dim
 ) {
   using TenT = GQTensor<TenElemT, QNT>;
@@ -288,6 +286,7 @@ void ExtendDirectRandomInitMps(
 
   // Calculate total quantum number
   auto div = pb_out_set[0].GetQNSctFromActualCoor(stat_labs_set[0][0]).GetQn();
+  const QNT zero_div = div-div;
   for (size_t i = 1; i < N; ++i) {
     div += pb_out_set[i].GetQNSctFromActualCoor(stat_labs_set[0][i]).GetQn();
   }
@@ -298,9 +297,10 @@ void ExtendDirectRandomInitMps(
     auto rvb_qn = div - pb_out_set[0].GetQNSctFromActualCoor(stat_lab).GetQn();
     rvb_qnscts.push_back(QNSctT(rvb_qn, enlarged_dim));
   }
+  lvb = IndexT({QNSctT(zero_div, 1)}, GQTenIndexDirType::IN);
   rvb = IndexT(rvb_qnscts, GQTenIndexDirType::OUT);
   rvb_qnscts.clear();
-  mps(0) = new TenT({pb_out_set[0], rvb});
+  mps(0) = new TenT({lvb, pb_out_set[0], rvb});
   mps[0].Random(div);
 
   // Deal with MPS middle local tensors
@@ -308,9 +308,8 @@ void ExtendDirectRandomInitMps(
     lvb = InverseIndex(rvb);
     for (size_t j = 0; j < fusion_stats_num; ++j) {
       auto stat_lab = stat_labs_set[j][i];
-      auto rvb_qn = zero_div -
-                    pb_out_set[i].GetQNSctFromActualCoor(stat_lab).GetQn() +
-                    lvb.GetQNSctFromActualCoor(j*enlarged_dim).GetQn();
+      auto rvb_qn = lvb.GetQNSctFromActualCoor(j*enlarged_dim).GetQn() -
+                    pb_out_set[i].GetQNSctFromActualCoor(stat_lab).GetQn();
       rvb_qnscts.push_back(QNSctT(rvb_qn, enlarged_dim));
     }
     rvb = IndexT(rvb_qnscts, GQTenIndexDirType::OUT);
@@ -321,7 +320,8 @@ void ExtendDirectRandomInitMps(
 
   // Deal with MPS tail local tensor
   lvb = InverseIndex(rvb);
-  mps(N-1) = new TenT({lvb, pb_out_set[N-1]});
+  rvb = IndexT({QNSctT(zero_div, 1)}, GQTenIndexDirType::OUT);
+  mps(N-1) = new TenT({lvb, pb_out_set[N-1], rvb});
   mps[N-1].Random(zero_div);
 
   // Centralize MPS.

--- a/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps_init.h
+++ b/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps_init.h
@@ -233,10 +233,12 @@ void DirectStateInitMps(
   for (size_t i = 1; i < N; ++i) {
     div += pb_out_set[i].GetQNSctFromActualCoor(stat_labs[i]).GetQn();
   }
+  // Calculate zero quantum number
+  auto zero_qn = div - div;
 
   auto stat_lab = stat_labs[0];
   auto rvb_qn = div - pb_out_set[0].GetQNSctFromActualCoor(stat_lab).GetQn();
-  lvb = IndexT({QNSctT(div-div, 1)}, GQTenIndexDirType::IN);
+  lvb = IndexT({QNSctT(zero_qn, 1)}, GQTenIndexDirType::IN);
   rvb = IndexT({QNSctT(rvb_qn, 1)}, GQTenIndexDirType::OUT);
   mps(0) = new TenT({lvb, pb_out_set[0], rvb});
   (mps[0])({0, stat_lab, 0}) = 1;
@@ -244,14 +246,15 @@ void DirectStateInitMps(
   for (size_t i = 1; i < N-1; ++i) {
     lvb = InverseIndex(rvb);
     stat_lab = stat_labs[i];
-    rvb_qn = lvb.GetQNSctFromActualCoor(0).GetQn() -pb_out_set[i].GetQNSctFromActualCoor(stat_lab).GetQn();
+    rvb_qn = lvb.GetQNSctFromActualCoor(0).GetQn() -
+             pb_out_set[i].GetQNSctFromActualCoor(stat_lab).GetQn();
     rvb = IndexT({QNSctT(rvb_qn, 1)}, GQTenIndexDirType::OUT);
     mps(i) = new TenT({lvb, pb_out_set[i], rvb});
     (mps[i])({0, stat_lab, 0}) = 1;
   }
 
   lvb = InverseIndex(rvb);
-  rvb = IndexT({QNSctT(div-div, 1)}, GQTenIndexDirType::OUT);
+  rvb = IndexT({QNSctT(zero_qn, 1)}, GQTenIndexDirType::OUT);
   mps(N-1) = new TenT({lvb, pb_out_set[N-1], rvb});
   stat_lab = stat_labs[N-1];
   (mps[N-1])({0, stat_lab, 0}) = 1;
@@ -286,10 +289,11 @@ void ExtendDirectRandomInitMps(
 
   // Calculate total quantum number
   auto div = pb_out_set[0].GetQNSctFromActualCoor(stat_labs_set[0][0]).GetQn();
-  const QNT zero_div = div-div;
   for (size_t i = 1; i < N; ++i) {
     div += pb_out_set[i].GetQNSctFromActualCoor(stat_labs_set[0][i]).GetQn();
   }
+  // Calculate zero quantum number
+  auto zero_qn = div-div;
 
   // Deal with MPS head local tensor
   for (size_t i = 0; i < fusion_stats_num; ++i) {
@@ -297,7 +301,7 @@ void ExtendDirectRandomInitMps(
     auto rvb_qn = div - pb_out_set[0].GetQNSctFromActualCoor(stat_lab).GetQn();
     rvb_qnscts.push_back(QNSctT(rvb_qn, enlarged_dim));
   }
-  lvb = IndexT({QNSctT(zero_div, 1)}, GQTenIndexDirType::IN);
+  lvb = IndexT({QNSctT(zero_qn, 1)}, GQTenIndexDirType::IN);
   rvb = IndexT(rvb_qnscts, GQTenIndexDirType::OUT);
   rvb_qnscts.clear();
   mps(0) = new TenT({lvb, pb_out_set[0], rvb});
@@ -308,21 +312,21 @@ void ExtendDirectRandomInitMps(
     lvb = InverseIndex(rvb);
     for (size_t j = 0; j < fusion_stats_num; ++j) {
       auto stat_lab = stat_labs_set[j][i];
-      auto rvb_qn = lvb.GetQNSctFromActualCoor(j*enlarged_dim).GetQn() -
+      auto rvb_qn = lvb.GetQNSctFromActualCoor(j * enlarged_dim).GetQn() -
                     pb_out_set[i].GetQNSctFromActualCoor(stat_lab).GetQn();
       rvb_qnscts.push_back(QNSctT(rvb_qn, enlarged_dim));
     }
     rvb = IndexT(rvb_qnscts, GQTenIndexDirType::OUT);
     mps(i) = new TenT({lvb, pb_out_set[i], rvb});
     rvb_qnscts.clear();
-    mps[i].Random(zero_div);
+    mps[i].Random(zero_qn);
   }
 
   // Deal with MPS tail local tensor
   lvb = InverseIndex(rvb);
-  rvb = IndexT({QNSctT(zero_div, 1)}, GQTenIndexDirType::OUT);
+  rvb = IndexT({QNSctT(zero_qn, 1)}, GQTenIndexDirType::OUT);
   mps(N-1) = new TenT({lvb, pb_out_set[N-1], rvb});
-  mps[N-1].Random(zero_div);
+  mps[N-1].Random(zero_qn);
 
   // Centralize MPS.
   mps.Centralize(0);

--- a/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps_measu.h
+++ b/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps_measu.h
@@ -103,8 +103,8 @@ void DumpMeasuRes(const MeasuRes<AvgT> &, const std::string &);
 
 // Helpers.
 inline bool IsOrderKept(const std::vector<size_t> &sites) {
-  for (std::size_t i = 0; i < sites.size()-1; ++i){
-    if (sites[i] > sites[i+1]){return false;}
+  for (size_t i = 0; i < sites.size() - 1; ++i){
+    if (sites[i] > sites[i+1]) { return false; }
   }
   return true;
 }
@@ -369,12 +369,10 @@ MeasuResElem<TenElemT> OneSiteOpAvg(
     const size_t site,
     const size_t N
 ) {
-  std::vector<size_t> ta_ctrct_axes1, tb_ctrct_axes1;
-  std::vector<size_t> ta_ctrct_axes2, tb_ctrct_axes2;
-  ta_ctrct_axes1 = {1};
-  tb_ctrct_axes1 = {0};
-  ta_ctrct_axes2 = {0, 2, 1};
-  tb_ctrct_axes2 = {0, 1, 2};
+  std::vector<size_t> ta_ctrct_axes1 {1};
+  std::vector<size_t> tb_ctrct_axes1 {0};
+  std::vector<size_t> ta_ctrct_axes2 {0, 2, 1};
+  std::vector<size_t> tb_ctrct_axes2 {0, 1, 2};
   GQTensor<TenElemT, QNT> temp_ten, res_ten;
   Contract(&cent_ten, &op, {ta_ctrct_axes1, tb_ctrct_axes1}, &temp_ten);
   auto cent_ten_dag = Dag(cent_ten);
@@ -455,12 +453,9 @@ TenElemT OpsVecAvg(
 ) {
   auto id_op_set = mps.GetSitesInfo().id_ops;
   // Deal with head tensor.
-  std::vector<size_t> head_mps_ten_ctrct_axes1;
-  std::vector<size_t> head_mps_ten_ctrct_axes2;
-  std::vector<size_t> head_mps_ten_ctrct_axes3;
-  head_mps_ten_ctrct_axes1 = {1};
-  head_mps_ten_ctrct_axes2 = {0, 2};
-  head_mps_ten_ctrct_axes3 = {0, 1};
+  std::vector<size_t> head_mps_ten_ctrct_axes1 {1};
+  std::vector<size_t> head_mps_ten_ctrct_axes2 {0, 2};
+  std::vector<size_t> head_mps_ten_ctrct_axes3 {0, 1};
   GQTensor<TenElemT, QNT> temp_ten0;
   auto ptemp_ten = new GQTensor<TenElemT, QNT>;
   Contract(
@@ -482,10 +477,8 @@ TenElemT OpsVecAvg(
   }
 
   // Deal with tail tensor.
-  std::vector<size_t> tail_mps_ten_ctrct_axes1;
-  std::vector<size_t> tail_mps_ten_ctrct_axes2;
-  tail_mps_ten_ctrct_axes1 = {0, 1, 2};
-  tail_mps_ten_ctrct_axes2 = {2, 0, 1};
+  std::vector<size_t> tail_mps_ten_ctrct_axes1 {0, 1, 2};
+  std::vector<size_t> tail_mps_ten_ctrct_axes2 {2, 0, 1};
   GQTensor<TenElemT, QNT> temp_ten2, temp_ten3, res_ten;
   Contract(&mps[tail_site], ptemp_ten, {{0}, {0}}, &temp_ten2);
   delete ptemp_ten;

--- a/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps_measu.h
+++ b/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps_measu.h
@@ -103,10 +103,8 @@ void DumpMeasuRes(const MeasuRes<AvgT> &, const std::string &);
 
 // Helpers.
 inline bool IsOrderKept(const std::vector<size_t> &sites) {
-  auto ordered_sites = sites;
-  std::sort(ordered_sites.begin(), ordered_sites.end());
-  for (std::size_t i = 0; i < sites.size(); ++i) {
-    if (sites[i] != ordered_sites[i]) { return false; }
+  for (std::size_t i = 0; i < sites.size()-1; ++i){
+    if (sites[i] > sites[i+1]){return false;}
   }
   return true;
 }
@@ -373,22 +371,10 @@ MeasuResElem<TenElemT> OneSiteOpAvg(
 ) {
   std::vector<size_t> ta_ctrct_axes1, tb_ctrct_axes1;
   std::vector<size_t> ta_ctrct_axes2, tb_ctrct_axes2;
-  if (site == 0) {
-    ta_ctrct_axes1 = {0};
-    tb_ctrct_axes1 = {0};
-    ta_ctrct_axes2 = {0, 1};
-    tb_ctrct_axes2 = {1, 0};
-  } else if (site == (N-1)) {
-    ta_ctrct_axes1 = {1};
-    tb_ctrct_axes1 = {0};
-    ta_ctrct_axes2 = {0, 1};
-    tb_ctrct_axes2 = {0, 1};
-  } else {
-    ta_ctrct_axes1 = {1};
-    tb_ctrct_axes1 = {0};
-    ta_ctrct_axes2 = {0, 2, 1};
-    tb_ctrct_axes2 = {0, 1, 2};
-  }
+  ta_ctrct_axes1 = {1};
+  tb_ctrct_axes1 = {0};
+  ta_ctrct_axes2 = {0, 2, 1};
+  tb_ctrct_axes2 = {0, 1, 2};
   GQTensor<TenElemT, QNT> temp_ten, res_ten;
   Contract(&cent_ten, &op, {ta_ctrct_axes1, tb_ctrct_axes1}, &temp_ten);
   auto cent_ten_dag = Dag(cent_ten);
@@ -472,15 +458,9 @@ TenElemT OpsVecAvg(
   std::vector<size_t> head_mps_ten_ctrct_axes1;
   std::vector<size_t> head_mps_ten_ctrct_axes2;
   std::vector<size_t> head_mps_ten_ctrct_axes3;
-  if (head_site == 0) {
-    head_mps_ten_ctrct_axes1 = {0};
-    head_mps_ten_ctrct_axes2 = {1};
-    head_mps_ten_ctrct_axes3 = {0};
-  } else {
-    head_mps_ten_ctrct_axes1 = {1};
-    head_mps_ten_ctrct_axes2 = {0, 2};
-    head_mps_ten_ctrct_axes3 = {0, 1};
-  }
+  head_mps_ten_ctrct_axes1 = {1};
+  head_mps_ten_ctrct_axes2 = {0, 2};
+  head_mps_ten_ctrct_axes3 = {0, 1};
   GQTensor<TenElemT, QNT> temp_ten0;
   auto ptemp_ten = new GQTensor<TenElemT, QNT>;
   Contract(
@@ -504,13 +484,8 @@ TenElemT OpsVecAvg(
   // Deal with tail tensor.
   std::vector<size_t> tail_mps_ten_ctrct_axes1;
   std::vector<size_t> tail_mps_ten_ctrct_axes2;
-  if (tail_site == mps.size()-1) {
-    tail_mps_ten_ctrct_axes1 = {0, 1};
-    tail_mps_ten_ctrct_axes2 = {0, 1};
-  } else {
-    tail_mps_ten_ctrct_axes1 = {0, 1, 2};
-    tail_mps_ten_ctrct_axes2 = {2, 0, 1};
-  }
+  tail_mps_ten_ctrct_axes1 = {0, 1, 2};
+  tail_mps_ten_ctrct_axes2 = {2, 0, 1};
   GQTensor<TenElemT, QNT> temp_ten2, temp_ten3, res_ten;
   Contract(&mps[tail_site], ptemp_ten, {{0}, {0}}, &temp_ten2);
   delete ptemp_ten;

--- a/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps_ops.h
+++ b/include/gqmps2/one_dim_tn/mps/finite_mps/finite_mps_ops.h
@@ -44,7 +44,7 @@ void FiniteMPSAdd(
   for (size_t i = 0; i < N; ++i) {
     mps_c.alloc(i);
     if (i == 0) {
-      Expand(mps_a(i), mps_b(i), {1}, mps_c(i));
+      Expand(mps_a(i), mps_b(i), {2}, mps_c(i));
     } else if (i == N - 1) {
       Expand(mps_a(i), mps_b(i), {0}, mps_c(i));
     } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,11 @@ add_unittest(test_two_site_algo
   "test_algorithm/test_two_site_update_finite_vmps.cc"
   "" "" "${MATH_LIB_LINK_FLAGS}" ""
 )
+# Single-site update finite vMPS
+add_unittest(test_single_site_algo
+        "test_algorithm/test_single_site_update_finite_vmps.cc"
+        "" "" "${MATH_LIB_LINK_FLAGS}" ""
+        )
 
 ## Test simulation case parameters parser.
 add_unittest(test_case_params_parser

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,9 +108,9 @@ add_unittest(test_two_site_algo
 )
 # Single-site update finite vMPS
 add_unittest(test_single_site_algo
-        "test_algorithm/test_single_site_update_finite_vmps.cc"
-        "" "" "${MATH_LIB_LINK_FLAGS}" ""
-        )
+  "test_algorithm/test_single_site_update_finite_vmps.cc"
+  "${MATH_LIB_COMPILE_FLAGS}" "" "${MATH_LIB_LINK_FLAGS}" ""
+)
 
 ## Test simulation case parameters parser.
 add_unittest(test_case_params_parser

--- a/tests/test_algorithm/test_lanczos_solver.cc
+++ b/tests/test_algorithm/test_lanczos_solver.cc
@@ -60,7 +60,7 @@ void RunTestTwoSiteLanczosSolverCase(
 ) {
   using TenT = GQTensor<TenElemT, QNT>;
 
-  Timer timer("cent_lancz");
+  Timer timer("two_site_lancz");
   auto lancz_res = LanczosSolver(
                        eff_ham, pinit_state,
                        &eff_ham_mul_two_site_state,

--- a/tests/test_algorithm/test_lanczos_solver.cc
+++ b/tests/test_algorithm/test_lanczos_solver.cc
@@ -53,7 +53,7 @@ struct TestLanczos : public testing::Test {
 
 
 template <typename TenElemT, typename QNT>
-void RunTestCentLanczosSolverCase(
+void RunTestTwoSiteLanczosSolverCase(
     const std::vector<GQTensor<TenElemT, QNT> *> &eff_ham,
     GQTensor<TenElemT, QNT> *pinit_state,
     const LanczosParams &lanczos_params
@@ -63,8 +63,8 @@ void RunTestCentLanczosSolverCase(
   Timer timer("cent_lancz");
   auto lancz_res = LanczosSolver(
                        eff_ham, pinit_state,
-                       lanczos_params,
-                       "cent"
+                       &eff_ham_mul_two_site_state,
+                       lanczos_params
                    );
   timer.PrintElapsed();
 
@@ -118,7 +118,7 @@ void RunTestCentLanczosSolverCase(
 }
 
 
-TEST_F(TestLanczos, TestCentLanczosSolver) {
+TEST_F(TestLanczos, TestTwoSiteLanczosSolver) {
   // Tensor with double elements.
   auto dlblock = DGQTensor({idx_Dout, idx_vout, idx_Din});
   auto dlsite  = DGQTensor({idx_vin, idx_din, idx_dout, idx_vout});
@@ -151,7 +151,7 @@ TEST_F(TestLanczos, TestCentLanczosSolver) {
   srand(0);
   pdinit_state->Random(qn0);
   LanczosParams lanczos_params(1.0E-9);
-  RunTestCentLanczosSolverCase(
+  RunTestTwoSiteLanczosSolverCase(
       {&dlblock, &dlsite, &drsite, &drblock},
       pdinit_state,
       lanczos_params
@@ -162,7 +162,7 @@ TEST_F(TestLanczos, TestCentLanczosSolver) {
   srand(0);
   pdinit_state->Random(qn0);
   LanczosParams lanczos_params2(1.0E-16, 20);
-  RunTestCentLanczosSolverCase(
+  RunTestTwoSiteLanczosSolverCase(
       {&dlblock, &dlsite, &drsite, &drblock},
       pdinit_state,
       lanczos_params2);
@@ -198,146 +198,11 @@ TEST_F(TestLanczos, TestCentLanczosSolver) {
   // Finish iteration when Lanczos error targeted.
   srand(0);
   pzinit_state->Random(qn0);
-  RunTestCentLanczosSolverCase(
+  RunTestTwoSiteLanczosSolverCase(
       {&zlblock, &zlsite, &zrsite, &zrblock},
       pzinit_state,
       lanczos_params
   );
 }
 
-
-template <typename TenElemT, typename QNT>
-void RunTestLendLanczosSolverCase(
-    const std::vector<GQTensor<TenElemT, QNT> *> &eff_ham,
-    GQTensor<TenElemT, QNT> *pinit_state,
-    const LanczosParams &lanczos_params
-) {
-  using TenT = GQTensor<TenElemT, QNT>;
-
-  Timer timer("lend_lancz");
-  auto lancz_res = LanczosSolver(
-                       eff_ham, pinit_state,
-                       lanczos_params,
-                       "lend"
-                   );
-  timer.PrintElapsed();
-
-  std::vector<size_t> ta_ctrct_axes1 = {1};
-  std::vector<size_t> ta_ctrct_axes2 = {4};
-  std::vector<size_t> tb_ctrct_axes1 = {0};
-  std::vector<size_t> tb_ctrct_axes2 = {1};
-  auto eff_ham_ten = new TenT;
-  Contract(eff_ham[1], eff_ham[2], {{1}, {0}}, eff_ham_ten);
-  InplaceContract(eff_ham_ten, eff_ham[3], {{4}, {1}});
-  eff_ham_ten->Transpose({0, 2, 4, 1, 3, 5});
-
-  auto dense_mat_dim = d * d * D;
-  auto dense_mat_size = dense_mat_dim * dense_mat_dim;
-  auto dense_mat = (TenElemT *) malloc(
-                       dense_mat_size * sizeof(TenElemT)
-                   );
-  std::vector<std::pair<size_t, size_t>> eff_mat_coors_list;
-  eff_mat_coors_list.reserve(dense_mat_size);
-  for (size_t i = 0; i < dense_mat_dim; ++i) {
-    for (size_t j = 0; j < dense_mat_dim; ++j) {
-      eff_mat_coors_list.emplace_back(std::make_pair(i, j));
-    }
-  }
-  size_t idx = 0;
-  for (auto &coors : GenAllCoors(eff_ham_ten->GetShape())) {
-    auto eff_mat_coors = eff_mat_coors_list[idx];
-    if (eff_mat_coors.first > eff_mat_coors.second) {
-      dense_mat[idx] = 0.0;
-    } else {
-      dense_mat[idx] = (*eff_ham_ten)(coors);
-    }
-    idx++;
-  }
-  auto w = new double [dense_mat_dim];
-  LapackeSyev(
-      LAPACK_ROW_MAJOR, 'N', 'U',
-      dense_mat_dim, dense_mat, dense_mat_dim, w
-  );
-
-  EXPECT_NEAR(lancz_res.gs_eng, w[0], 1.0E-8);
-
-  delete lancz_res.gs_vec;
-  delete eff_ham_ten;
-  delete[] w;
-  free(dense_mat);
-  mkl_free_buffers();
-}
-
-
-TEST_F(TestLanczos, TestLendLanczosSolver) {
-  // Tensor with double element.
-  auto dlsite = DGQTensor({idx_din, idx_vout, idx_dout});
-  auto drsite = DGQTensor({idx_vin, idx_din, idx_dout, idx_vout});
-  auto drblock = DGQTensor({idx_Din, idx_vin, idx_Dout});
-  auto dblock_random_mat = new double [D*D];
-  RandRealSymMat(dblock_random_mat, D);
-  for (size_t i = 0; i < D; ++i) {
-    for (size_t j = 0; j < D; ++j) {
-      for (size_t k = 0; k < dh; ++k) {
-        drblock({j, k, i}) = dblock_random_mat[(i*D+j)];
-      }
-    }
-  }
-  delete[] dblock_random_mat;
-  auto dsite_random_mat = new double [d*d];
-  RandRealSymMat(dsite_random_mat, d);
-  for (size_t i = 0; i < d; ++i) {
-    for (size_t j = 0; j < d; ++j) {
-      for (size_t k = 0; k < dh; ++k) {
-        dlsite({i, k, j}) = dsite_random_mat[(i*d+j)];
-        drsite({k, i, j, k}) = dsite_random_mat[(i*d+j)];
-      }
-    }
-  }
-  delete[] dsite_random_mat;
-  auto dnull_ten = DGQTensor();
-  auto pdinit_state = new DGQTensor({idx_dout, idx_dout, idx_Dout});
-
-  srand(0);
-  pdinit_state->Random(qn0);
-  LanczosParams lanczos_params(1.0E-9);
-  RunTestLendLanczosSolverCase(
-      {&dnull_ten, &dlsite, &drsite, &drblock},
-      pdinit_state,
-      lanczos_params);
-
-  // Tensor with complex element.
-  auto zlsite = ZGQTensor({idx_din, idx_vout, idx_dout});
-  auto zrsite = ZGQTensor({idx_vin, idx_din, idx_dout, idx_vout});
-  auto zrblock = ZGQTensor({idx_Din, idx_vin, idx_Dout});
-  auto zblock_random_mat = new GQTEN_Complex [D*D];
-  RandCplxHerMat(zblock_random_mat, D);
-  for (size_t i = 0; i < D; ++i) {
-    for (size_t j = 0; j < D; ++j) {
-      for (size_t k = 0; k < dh; ++k) {
-        zrblock({j, k, i}) = zblock_random_mat[(i*D+j)];
-      }
-    }
-  }
-  delete[] zblock_random_mat;
-  auto zsite_random_mat = new GQTEN_Complex [d*d];
-  RandCplxHerMat(zsite_random_mat, d);
-  for (size_t i = 0; i < d; ++i) {
-    for (size_t j = 0; j < d; ++j) {
-      for (size_t k = 0; k < dh; ++k) {
-        zlsite({i, k, j}) = zsite_random_mat[(i*d+j)];
-        zrsite({k, i, j, k}) = zsite_random_mat[(i*d+j)];
-      }
-    }
-  }
-  delete[] zsite_random_mat;
-  auto znull_ten = ZGQTensor();
-  auto pzinit_state = new ZGQTensor({idx_dout, idx_dout, idx_Dout});
-
-  srand(0);
-  pzinit_state->Random(qn0);
-  RunTestLendLanczosSolverCase(
-      {&znull_ten, &zlsite, &zrsite, &zrblock},
-      pzinit_state,
-      lanczos_params);
-}
+//TODO: Test for single site case

--- a/tests/test_algorithm/test_lanczos_solver.cc
+++ b/tests/test_algorithm/test_lanczos_solver.cc
@@ -205,4 +205,138 @@ TEST_F(TestLanczos, TestTwoSiteLanczosSolver) {
   );
 }
 
-//TODO: Test for single site case
+
+template <typename TenElemT, typename QNT>
+void RunTestSingleSiteLanczosSolverCase(
+		const std::vector<GQTensor<TenElemT, QNT> *> &eff_ham,
+		GQTensor<TenElemT, QNT> *pinit_state,
+		const LanczosParams &lanczos_params
+) {
+    using TenT = GQTensor<TenElemT, QNT>;
+    
+    Timer timer("single_site_lancz");
+    auto lancz_res = LanczosSolver(
+    		eff_ham, pinit_state,
+    		&eff_ham_mul_single_site_state,
+    		lanczos_params
+    );
+    timer.PrintElapsed();
+    
+    std::vector<size_t> ta_ctrct_axes1 = {1};
+    std::vector<size_t> ta_ctrct_axes2 = {4};
+    std::vector<size_t> tb_ctrct_axes1 = {0};
+    std::vector<size_t> tb_ctrct_axes2 = {1};
+    auto eff_ham_ten = new TenT;
+    Contract(eff_ham[0], eff_ham[1], {{1}, {0}}, eff_ham_ten);
+    InplaceContract(eff_ham_ten, eff_ham[2], {{4}, {1}});
+    eff_ham_ten->Transpose({0, 2, 4, 1, 3, 5});
+    
+    auto dense_mat_dim = d * d * D;
+    auto dense_mat_size = dense_mat_dim * dense_mat_dim;
+    auto dense_mat = (TenElemT *) malloc(
+    		dense_mat_size * sizeof(TenElemT)
+    );
+    std::vector<std::pair<size_t, size_t>> eff_mat_coors_list;
+    eff_mat_coors_list.reserve(dense_mat_size);
+    for (size_t i = 0; i < dense_mat_dim; ++i) {
+    	for (size_t j = 0; j < dense_mat_dim; ++j) {
+    		eff_mat_coors_list.emplace_back(std::make_pair(i, j));
+    	}
+    }
+    size_t idx = 0;
+    for (auto &coors : GenAllCoors(eff_ham_ten->GetShape())) {
+    	auto eff_mat_coors = eff_mat_coors_list[idx];
+    	if (eff_mat_coors.first > eff_mat_coors.second) {
+    		dense_mat[idx] = 0.0;
+    	} else {
+    		dense_mat[idx] = (*eff_ham_ten)(coors);
+    	}
+    	idx++;
+    }
+    auto w = new double [dense_mat_dim];
+    LapackeSyev(
+    		LAPACK_ROW_MAJOR, 'N', 'U',
+    dense_mat_dim, dense_mat, dense_mat_dim, w
+);
+
+EXPECT_NEAR(lancz_res.gs_eng, w[0], 1.0E-8);
+
+delete lancz_res.gs_vec;
+delete eff_ham_ten;
+delete[] w;
+free(dense_mat);
+mkl_free_buffers();
+}
+
+
+
+TEST_F(TestLanczos, TestSingleSiteLanczosSolver) {
+	// Tensor with double element.
+	auto dlsite = DGQTensor({idx_din, idx_vout, idx_dout});
+	auto drsite = DGQTensor({idx_vin, idx_din, idx_dout, idx_vout});
+	auto drblock = DGQTensor({idx_Din, idx_vin, idx_Dout});
+	auto dblock_random_mat = new double [D*D];
+	RandRealSymMat(dblock_random_mat, D);
+	for (size_t i = 0; i < D; ++i) {
+		for (size_t j = 0; j < D; ++j) {
+			for (size_t k = 0; k < dh; ++k) {
+				drblock({j, k, i}) = dblock_random_mat[(i*D+j)];
+			}
+		}
+	}
+	delete[] dblock_random_mat;
+	auto dsite_random_mat = new double [d*d];
+	RandRealSymMat(dsite_random_mat, d);
+	for (size_t i = 0; i < d; ++i) {
+		for (size_t j = 0; j < d; ++j) {
+			for (size_t k = 0; k < dh; ++k) {
+				dlsite({i, k, j}) = dsite_random_mat[(i*d+j)];
+				drsite({k, i, j, k}) = dsite_random_mat[(i*d+j)];
+			}
+		}
+	}
+	delete[] dsite_random_mat;
+	auto pdinit_state = new DGQTensor({idx_dout, idx_dout, idx_Dout});
+
+	srand(0);
+	pdinit_state->Random(qn0);
+	LanczosParams lanczos_params(1.0E-9);
+	RunTestSingleSiteLanczosSolverCase(
+		{&dlsite, &drsite, &drblock},
+		pdinit_state,
+	lanczos_params);
+
+	// Tensor with complex element.
+	auto zlblock = ZGQTensor({idx_din, idx_vout, idx_dout});
+	auto zrsite = ZGQTensor({idx_vin, idx_din, idx_dout, idx_vout});
+	auto zrblock = ZGQTensor({idx_Din, idx_vin, idx_Dout});
+	auto zblock_random_mat = new GQTEN_Complex [D*D];
+	RandCplxHerMat(zblock_random_mat, D);
+	for (size_t i = 0; i < D; ++i) {
+		for (size_t j = 0; j < D; ++j) {
+			for (size_t k = 0; k < dh; ++k) {
+			zrblock({j, k, i}) = zblock_random_mat[(i*D+j)];
+			}
+		}
+	}
+	delete[] zblock_random_mat;
+	auto zsite_random_mat = new GQTEN_Complex [d*d];
+	RandCplxHerMat(zsite_random_mat, d);
+	for (size_t i = 0; i < d; ++i) {
+		for (size_t j = 0; j < d; ++j) {
+			for (size_t k = 0; k < dh; ++k) {
+				zlblock({i, k, j}) = zsite_random_mat[(i*d+j)];
+				zrsite({k, i, j, k}) = zsite_random_mat[(i*d+j)];
+			}
+		}
+	}
+	delete[] zsite_random_mat;
+	auto pzinit_state = new ZGQTensor({idx_dout, idx_dout, idx_Dout});
+
+	srand(0);
+	pzinit_state->Random(qn0);
+	RunTestSingleSiteLanczosSolverCase(
+		{&zlblock, &zrsite, &zrblock},
+		pzinit_state,
+		lanczos_params);
+}

--- a/tests/test_algorithm/test_lanczos_solver.cc
+++ b/tests/test_algorithm/test_lanczos_solver.cc
@@ -269,7 +269,6 @@ mkl_free_buffers();
 }
 
 
-
 TEST_F(TestLanczos, TestSingleSiteLanczosSolver) {
 	// Tensor with double element.
 	auto dlsite = DGQTensor({idx_din, idx_vout, idx_dout});
@@ -302,9 +301,10 @@ TEST_F(TestLanczos, TestSingleSiteLanczosSolver) {
 	pdinit_state->Random(qn0);
 	LanczosParams lanczos_params(1.0E-9);
 	RunTestSingleSiteLanczosSolverCase(
-		{&dlsite, &drsite, &drblock},
-		pdinit_state,
-	lanczos_params);
+		  {&dlsite, &drsite, &drblock},
+		  pdinit_state,
+	    lanczos_params
+  );
 
 	// Tensor with complex element.
 	auto zlblock = ZGQTensor({idx_din, idx_vout, idx_dout});
@@ -336,7 +336,8 @@ TEST_F(TestLanczos, TestSingleSiteLanczosSolver) {
 	srand(0);
 	pzinit_state->Random(qn0);
 	RunTestSingleSiteLanczosSolverCase(
-		{&zlblock, &zrsite, &zrblock},
-		pzinit_state,
-		lanczos_params);
+		  {&zlblock, &zrsite, &zrblock},
+		  pzinit_state,
+		  lanczos_params
+  );
 }

--- a/tests/test_algorithm/test_single_site_update_finite_vmps.cc
+++ b/tests/test_algorithm/test_single_site_update_finite_vmps.cc
@@ -86,6 +86,7 @@ void RunTestSingleSiteAlgorithmCase(
   auto e0 = SingleSiteFiniteVMPS(mps, mpo, sweep_params);
   EXPECT_NEAR(e0, benmrk_e0, precision);
   EXPECT_TRUE(mps.empty());
+  mkl_free_buffers();
 }
 
 

--- a/tests/test_algorithm/test_single_site_update_finite_vmps.cc
+++ b/tests/test_algorithm/test_single_site_update_finite_vmps.cc
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 /*
-* Author: Rongyang Sun <sun-rongyang@outlook.com>
-* Creation Date: 2019-05-14 16:08
+* Author: Hao-Xin Wang
+*         Rongyang Sun <sun-rongyang@outlook.com>
+* Creation Date: 2021-06-30
 *
-* Description: GraceQ/mps2 project. Unittest for two sites algorithm.
+* Description: GraceQ/mps2 project. Unittest for single site algorithm.
 */
 #include "gqmps2/gqmps2.h"
 #include "gtest/gtest.h"
@@ -202,7 +203,7 @@ TEST_F(TestSingleSiteAlgorithmSpinSystem, 1DHeisenberg) {
                           6,
                           8, 8, 1.0E-9,
                           LanczosParams(1.0E-7),
-                          {0.01,0.001,0.0001,0.00001}
+                          {0.01, 0.001, 0.0001, 0.00001}
                       );
   std::vector<size_t> stat_labs;
   for (size_t i = 0; i < N; ++i) { stat_labs.push_back(i % 2); }
@@ -235,7 +236,7 @@ TEST_F(TestSingleSiteAlgorithmSpinSystem, 1DHeisenberg) {
                      6,
                      8, 8, 1.0E-9,
                      LanczosParams(1.0E-7),
-                     {0.01,0.001,0.0001,0.00001}
+                     {0.01, 0.001, 0.0001, 0.00001}
                  );
   DirectStateInitMps(zmps, stat_labs);
   zmps.Dump(sweep_params.mps_path, true);
@@ -270,7 +271,7 @@ TEST_F(TestSingleSiteAlgorithmSpinSystem, 2DHeisenberg) {
                           6,
                           8, 8, 1.0E-9,
                           LanczosParams(1.0E-7),
-                          {0.01,0.001,0.0001,0.00001}
+                          {0.01, 0.001, 0.0001, 0.00001}
                       );
 
   // Test direct product state initialization.
@@ -298,7 +299,7 @@ TEST_F(TestSingleSiteAlgorithmSpinSystem, 2DHeisenberg) {
                      6,
                      8, 8, 1.0E-9,
                      LanczosParams(1.0E-7),
-                     {0.01,0.001,0.0001,0.00001}
+                     {0.01, 0.001, 0.0001, 0.00001}
                  );
   DirectStateInitMps(zmps, stat_labs);
   zmps.Dump(sweep_params.mps_path, true);
@@ -333,7 +334,7 @@ TEST_F(TestSingleSiteAlgorithmSpinSystem, 2DKitaevSimpleCase) {
                           4,
                           8, 8, 1.0E-4,
                           LanczosParams(1.0E-10),
-                          {0.01,0.001,0.0001,0.00001}
+                          {0.01, 0.001, 0.0001, 0.00001}
                       );
   // Test extend direct product state random initialization.
   std::vector<size_t> stat_labs1, stat_labs2;
@@ -370,7 +371,8 @@ TEST_F(TestSingleSiteAlgorithmSpinSystem, 2DKitaevSimpleCase) {
   zmps_8sites.Dump(sweep_params.mps_path, true);
   RunTestSingleSiteAlgorithmCase(
       zmps_8sites, zmpo, sweep_params,
-      -1.0, 1.0E-12);
+      -1.0, 1.0E-12
+  );
   RemoveFolder(sweep_params.mps_path);
   RemoveFolder(sweep_params.temp_path);
 }
@@ -483,11 +485,14 @@ TEST(TestSingleSiteAlgorithmNoSymmetrySpinSystem, 2DKitaevComplexCase) {
                           4,
                           60, 60, 1.0E-4,
                           LanczosParams(1.0E-10),
-                          {0.01,0.001,0.0001,0.00001}
+                          {0.01, 0.001, 0.0001, 0.00001}
                       );
   DirectStateInitMps(mps, stat_labs);
   mps.Dump(sweep_params.mps_path, true);
-  RunTestSingleSiteAlgorithmCase(mps, mpo, sweep_params, -4.57509167674, 2.0E-10);
+  RunTestSingleSiteAlgorithmCase(
+      mps, mpo, sweep_params,
+      -4.57509167674, 2.0E-10
+  );
   RemoveFolder(sweep_params.mps_path);
   RemoveFolder(sweep_params.temp_path);
 }
@@ -574,7 +579,7 @@ TEST_F(TestSingleSiteAlgorithmTjSystem2U1Symm, 1DCase) {
                           11,
                           8, 8, 1.0E-9,
                           LanczosParams(1.0E-8, 20),
-                          {0.01,0.001,0.0001,0.00001}
+                          {0.01, 0.001, 0.0001, 0.00001}
                       );
   DirectStateInitMps(dmps, {2, 1, 2, 0});
   dmps.Dump(sweep_params.mps_path, true);
@@ -784,7 +789,7 @@ TEST_F(TestSingleSiteAlgorithmTjSystem1U1Symm, RashbaTermCase) {
                           8,
                           30, 30, 1.0E-4,
                           LanczosParams(1.0E-14, 100),
-                          {0.01,0.001,0.0001,0.00001}
+                          {0.01, 0.001, 0.0001, 0.00001}
                       );
   auto mps = ZMPS(site_vec);
   DirectStateInitMps(mps, {0, 1, 0, 2, 0, 1});
@@ -948,7 +953,7 @@ TEST_F(TestSingleSiteAlgorithmHubbardSystem, 2Dcase) {
                           10,
                           16, 16, 1.0E-9,
                           LanczosParams(1.0E-8, 20),
-                          {0.1, 0.01,0.001}
+                          {0.1, 0.01, 0.001}
                       );
   auto qn0 = U1U1QN({QNCard("Nup", U1QNVal(0)), QNCard("Ndn", U1QNVal(0))});
   std::vector<size_t> stat_labs(N);
@@ -1106,11 +1111,11 @@ TEST_F(TestKondoInsulatorSystem, doublechain) {
   auto dmpo = dmpo_gen.Gen();
 
   auto sweep_params = SweepParams(
-    5,
-    64, 64, 1.0E-9,
-    LanczosParams(1.0E-8, 20),
-    {0.01, 0.001}
-  );
+                          5,
+                          64, 64, 1.0E-9,
+                          LanczosParams(1.0E-8, 20),
+                          {0.01, 0.001}
+                      );
 
   std::vector<size_t> stat_labs;
   for (size_t i = 0; i < N; ++i) { stat_labs.push_back(i % 2); }
@@ -1139,13 +1144,15 @@ struct TestSingleSiteAlgorithmElectronPhononSystem : public testing::Test {
 
   U1U1QN qn0 = U1U1QN({QNCard("N", U1QNVal(0)), QNCard("Sz", U1QNVal(0))});
   //Fermion(electron)
-  IndexT2 pb_outF = IndexT2({
-                               QNSctT2(U1U1QN({QNCard("N", U1QNVal(2)), QNCard("Sz", U1QNVal(0))}), 1),
-                               QNSctT2(U1U1QN({QNCard("N", U1QNVal(1)), QNCard("Sz", U1QNVal(1))}), 1),
-                               QNSctT2(U1U1QN({QNCard("N", U1QNVal(1)), QNCard("Sz", U1QNVal(-1))}), 1),
-                               QNSctT2(U1U1QN({QNCard("S", U1QNVal(0)), QNCard("Sz", U1QNVal(0))}), 1)},
-                           GQTenIndexDirType::OUT
-  );
+  IndexT2 pb_outF = IndexT2(
+                        {
+                            QNSctT2(U1U1QN({QNCard("N", U1QNVal(2)), QNCard("Sz", U1QNVal(0))}), 1),
+                            QNSctT2(U1U1QN({QNCard("N", U1QNVal(1)), QNCard("Sz", U1QNVal(1))}), 1),
+                            QNSctT2(U1U1QN({QNCard("N", U1QNVal(1)), QNCard("Sz", U1QNVal(-1))}), 1),
+                            QNSctT2(U1U1QN({QNCard("S", U1QNVal(0)), QNCard("Sz", U1QNVal(0))}), 1)
+                        },
+                        GQTenIndexDirType::OUT
+                    );
   IndexT2 pb_inF = InverseIndex(pb_outF);
   //Boson(Phonon)
   IndexT2 pb_outB = IndexT2({QNSctT2(qn0,2)}, GQTenIndexDirType::OUT);
@@ -1233,11 +1240,15 @@ struct TestSingleSiteAlgorithmElectronPhononSystem : public testing::Test {
     zP0   	=  ToComplex(P0   );
 
     for(size_t i =0; i < N; ++i){
-      if(i%(Np+1)==0) index_set[i] = pb_outF; // even site is fermion
-      else index_set[i] = pb_outB; // odd site is boson
+      if (i%(Np+1)==0) {
+        index_set[i] = pb_outF;     // even site is fermion
+      } else {
+        index_set[i] = pb_outB;     // odd site is boson
+      }
     }
   }
 };
+
 
 TEST_F(TestSingleSiteAlgorithmElectronPhononSystem, holsteinchain) {
   DSiteVec2 dsite_vec = DSiteVec2(index_set);
@@ -1270,11 +1281,12 @@ TEST_F(TestSingleSiteAlgorithmElectronPhononSystem, holsteinchain) {
     qn_label=3-qn_label;
   }
   DirectStateInitMps(dmps, stat_labs);
-  auto sweep_params = SweepParams(5,
-     256, 256, 1.0E-10,
-     LanczosParams(1.0E-7),
-      {0.1,0.1,0.01,0.001,0.0001}
-  );
+  auto sweep_params = SweepParams(
+                          5,
+                          256, 256, 1.0E-10,
+                          LanczosParams(1.0E-7),
+                          {0.1, 0.1, 0.01, 0.001, 0.0001}
+                      );
   dmps.Dump(sweep_params.mps_path, true);
 
   RunTestSingleSiteAlgorithmCase(
@@ -1300,10 +1312,10 @@ TEST_F(TestSingleSiteAlgorithmElectronPhononSystem, holsteinchain) {
     for(unsigned long j = 0; j < Np; ++j) {
     zmpo_gen.AddTerm(omega, (double)(pow(2,j))*zP1, i+j+1);
   }
-    zmpo_gen.AddTerm(2*g, {znf,  za,      za,    zadag},                  {i, i+1,  i+2,  i+3});
-    zmpo_gen.AddTerm(2*g, {znf,  zadag,   zadag, za},                     {i, i+1,  i+2,  i+3});
-    zmpo_gen.AddTerm(g,   {znf,  za,      zadag, sqrt(2)*zP0+sqrt(6)*zP1}, {i, i+1,  i+2,  i+3});
-    zmpo_gen.AddTerm(g,   {znf,  zadag,   za,    sqrt(2)*zP0+sqrt(6)*zP1}, {i, i+1,  i+2,  i+3});
+    zmpo_gen.AddTerm(2*g, {znf,  za,       za,    zadag},                   {i, i+1,  i+2,  i+3});
+    zmpo_gen.AddTerm(2*g, {znf,  zadag,    zadag, za},                      {i, i+1,  i+2,  i+3});
+    zmpo_gen.AddTerm(g,   {znf,  za,       zadag, sqrt(2)*zP0+sqrt(6)*zP1}, {i, i+1,  i+2,  i+3});
+    zmpo_gen.AddTerm(g,   {znf,  zadag,    za,    sqrt(2)*zP0+sqrt(6)*zP1}, {i, i+1,  i+2,  i+3});
     zmpo_gen.AddTerm(g,   {znf,  za+zadag, zP1,   sqrt(3)*zP0+sqrt(7)*zP1}, {i, i+1,  i+2,  i+3});
     zmpo_gen.AddTerm(g,   {znf,  za+zadag, zP0,   zP0+sqrt(5)*zP1},         {i, i+1,  i+2,  i+3});
 }
@@ -1315,9 +1327,8 @@ TEST_F(TestSingleSiteAlgorithmElectronPhononSystem, holsteinchain) {
 
   RunTestSingleSiteAlgorithmCase(
       zmps, zmpo, sweep_params,
-  -1.9363605088186260 , 1.0E-8
+      -1.9363605088186260 , 1.0E-8
   );
   RemoveFolder(sweep_params.mps_path);
   RemoveFolder(sweep_params.temp_path);
-
 }

--- a/tests/test_algorithm/test_single_site_update_finite_vmps.cc
+++ b/tests/test_algorithm/test_single_site_update_finite_vmps.cc
@@ -1,0 +1,1247 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+/*
+* Author: Rongyang Sun <sun-rongyang@outlook.com>
+* Creation Date: 2019-05-14 16:08
+*
+* Description: GraceQ/mps2 project. Unittest for two sites algorithm.
+*/
+#include "gqmps2/gqmps2.h"
+#include "gtest/gtest.h"
+#include "gqten/gqten.h"
+
+#include <vector>
+
+#include <stdlib.h>     // system
+
+
+using namespace gqmps2;
+using namespace gqten;
+
+using U1QN = QN<U1QNVal>;
+using U1U1QN = QN<U1QNVal, U1QNVal>;
+
+using IndexT = Index<U1QN>;
+using IndexT2 = Index<U1U1QN>;
+using QNSctT = QNSector<U1QN>;
+using QNSctT2 = QNSector<U1U1QN>;
+using QNSctVecT = QNSectorVec<U1QN>;
+using QNSctVecT2 = QNSectorVec<U1U1QN>;
+using DGQTensor = GQTensor<GQTEN_Double, U1QN>;
+using DGQTensor2 = GQTensor<GQTEN_Double, U1U1QN>;
+using ZGQTensor = GQTensor<GQTEN_Complex, U1QN>;
+using ZGQTensor2 = GQTensor<GQTEN_Complex, U1U1QN>;
+using DSiteVec = SiteVec<GQTEN_Double, U1QN>;
+using DSiteVec2 = SiteVec<GQTEN_Double, U1U1QN>;
+using ZSiteVec = SiteVec<GQTEN_Complex, U1QN>;
+using ZSiteVec2 = SiteVec<GQTEN_Complex, U1U1QN>;
+using DMPS = FiniteMPS<GQTEN_Double, U1QN>;
+using DMPS2 = FiniteMPS<GQTEN_Double, U1U1QN>;
+using ZMPS = FiniteMPS<GQTEN_Complex, U1QN>;
+using ZMPS2 = FiniteMPS<GQTEN_Complex, U1U1QN>;
+
+
+// Helpers
+inline void KeepOrder(size_t &x, size_t &y) {
+  if (x > y) {
+    auto temp = y;
+    y = x;
+    x = temp;
+  }
+}
+
+
+inline size_t coors2idx(
+    const size_t x, const size_t y, const size_t Nx, const size_t Ny) {
+	return x * Ny + y;
+}
+
+
+
+inline size_t coors2idxSquare(
+    const int x, const int y, const size_t Nx, const size_t Ny) {
+  return x * Ny + y;
+}
+
+
+inline size_t coors2idxHoneycomb(
+    const int x, const int y, const size_t Nx, const size_t Ny) {
+  return Ny * (x%Nx) + y%Ny;
+}
+
+
+inline void RemoveFolder(const std::string &folder_path) {
+  std::string command = "rm -rf " + folder_path;
+  system(command.c_str());
+}
+
+
+template <typename TenElemT, typename QNT>
+void RunTestSingleSiteAlgorithmCase(
+    FiniteMPS<TenElemT, QNT> &mps,
+    const MPO<GQTensor<TenElemT, QNT>> &mpo,
+    SweepParams sweep_params,
+    const double benmrk_e0, const double precision
+) {
+  auto e0 = SingleSiteFiniteVMPS(mps, mpo, sweep_params);
+  EXPECT_NEAR(e0, benmrk_e0, precision);
+  EXPECT_TRUE(mps.empty());
+}
+
+
+// Test spin systems
+struct TestSingleSiteAlgorithmSpinSystem : public testing::Test {
+  size_t N = 6;
+
+  U1QN qn0 = U1QN({QNCard("Sz", U1QNVal(0))});
+  IndexT pb_out = IndexT({
+                      QNSctT(U1QN({QNCard("Sz", U1QNVal( 1))}), 1),
+                      QNSctT(U1QN({QNCard("Sz", U1QNVal(-1))}), 1)},
+                      GQTenIndexDirType::OUT
+                  );
+  IndexT pb_in = InverseIndex(pb_out);
+  DSiteVec dsite_vec_6 = DSiteVec(N, pb_out);
+  ZSiteVec zsite_vec_6 = ZSiteVec(N, pb_out);
+
+  DGQTensor  did  = DGQTensor({pb_in, pb_out});
+  DGQTensor  dsz  = DGQTensor({pb_in, pb_out});
+  DGQTensor  dsp  = DGQTensor({pb_in, pb_out});
+  DGQTensor  dsm  = DGQTensor({pb_in, pb_out});
+  DMPS dmps = DMPS(dsite_vec_6);
+
+  ZGQTensor  zid  = ZGQTensor({pb_in, pb_out});
+  ZGQTensor  zsz  = ZGQTensor({pb_in, pb_out});
+  ZGQTensor  zsp  = ZGQTensor({pb_in, pb_out});
+  ZGQTensor  zsm  = ZGQTensor({pb_in, pb_out});
+  ZMPS zmps = ZMPS(zsite_vec_6);
+
+  void SetUp(void) {
+    did({0, 0}) = 1;
+    did({1, 1}) = 1;
+    dsz({0, 0}) = 0.5;
+    dsz({1, 1}) = -0.5;
+    dsp({0, 1}) = 1;
+    dsm({1, 0}) = 1;
+
+    zid({0, 0}) = 1;
+    zid({1, 1}) = 1;
+    zsz({0, 0}) = 0.5;
+    zsz({1, 1}) = -0.5;
+    zsp({0, 1}) = 1;
+    zsm({1, 0}) = 1;
+  }
+};
+
+
+TEST_F(TestSingleSiteAlgorithmSpinSystem, 1DIsing) {
+  auto dmpo_gen = MPOGenerator<GQTEN_Double, U1QN>(dsite_vec_6, qn0);
+  for (size_t i = 0; i < N-1; ++i) {
+    dmpo_gen.AddTerm(1, {dsz, dsz}, {i, i+1});
+  }
+  auto dmpo = dmpo_gen.Gen();
+
+  auto sweep_params = SweepParams(
+                          4,
+                          1, 10, 1.0E-5,
+                          LanczosParams(1.0E-7)
+                      );
+  std::vector<size_t> stat_labs;
+  for (size_t i = 0; i < N; ++i) { stat_labs.push_back(i % 2); }
+  DirectStateInitMps(dmps, stat_labs);
+  dmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(dmps, dmpo, sweep_params, -0.25*(N-1), 1.0E-10);
+
+  dmps.Load(sweep_params.mps_path);
+  MeasureOneSiteOp(dmps, dsz, "dsz");
+  std::vector<std::vector<size_t>> sites_set;
+  for (size_t i = 0; i < N; ++i) {
+    for (size_t j = 0; j < N; ++j) {
+      if (i < j) { sites_set.push_back({i, j}); }
+    }
+  }
+  MeasureTwoSiteOp(dmps, {dsz, dsz}, did, sites_set, "dszdsz");
+  dmps.clear();
+
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+
+  // Complex Hamiltonian
+  auto zmpo_gen = MPOGenerator<GQTEN_Complex, U1QN>(zsite_vec_6, qn0);
+  for (size_t i = 0; i < N-1; ++i) {
+    zmpo_gen.AddTerm(1, {zsz, zsz}, {i, i+1});
+  }
+  auto zmpo = zmpo_gen.Gen();
+  sweep_params = SweepParams(
+                     4,
+                     1, 10, 1.0E-5,
+                     LanczosParams(1.0E-7)
+                 );
+  DirectStateInitMps(zmps, stat_labs);
+  zmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(zmps, zmpo, sweep_params, -0.25*(N-1), 1.0E-10);
+
+  zmps.Load(sweep_params.mps_path);
+  MeasureOneSiteOp(zmps, zsz, "zsz");
+  MeasureTwoSiteOp(zmps, {zsz, zsz}, zid, sites_set, "zszzsz");
+  zmps.clear();
+
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+}
+
+
+TEST_F(TestSingleSiteAlgorithmSpinSystem, 1DHeisenberg) {
+  auto dmpo_gen = MPOGenerator<GQTEN_Double, U1QN>(dsite_vec_6, qn0);
+  for (size_t i = 0; i < N-1; ++i) {
+    dmpo_gen.AddTerm(1,   {dsz, dsz}, {i, i+1});
+    dmpo_gen.AddTerm(0.5, {dsp, dsm}, {i, i+1});
+    dmpo_gen.AddTerm(0.5, {dsm, dsp}, {i, i+1});
+  }
+  auto dmpo = dmpo_gen.Gen();
+
+  auto sweep_params = SweepParams(
+                          6,
+                          8, 8, 1.0E-9,
+                          LanczosParams(1.0E-7),
+                          {0.01,0.001,0.0001,0.00001}
+                      );
+  std::vector<size_t> stat_labs;
+  for (size_t i = 0; i < N; ++i) { stat_labs.push_back(i % 2); }
+  DirectStateInitMps(dmps, stat_labs);
+  dmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      dmps, dmpo, sweep_params,
+      -2.493577133888, 1.0E-12
+  );
+
+  // Continue simulation test
+  dmps.clear();
+  RunTestSingleSiteAlgorithmCase(
+      dmps, dmpo, sweep_params,
+      -2.493577133888, 1.0E-12
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+
+  // Complex Hamiltonian
+  auto zmpo_gen = MPOGenerator<GQTEN_Complex, U1QN>(zsite_vec_6, qn0);
+  for (size_t i = 0; i < N-1; ++i) {
+    zmpo_gen.AddTerm(1,   {zsz, zsz}, {i, i+1});
+    zmpo_gen.AddTerm(0.5, {zsp, zsm}, {i, i+1});
+    zmpo_gen.AddTerm(0.5, {zsm, zsp}, {i, i+1});
+  }
+  auto zmpo = zmpo_gen.Gen();
+
+  sweep_params = SweepParams(
+                     6,
+                     8, 8, 1.0E-9,
+                     LanczosParams(1.0E-7),
+                     {0.01,0.001,0.0001,0.00001}
+                 );
+  DirectStateInitMps(zmps, stat_labs);
+  zmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      zmps, zmpo, sweep_params,
+      -2.493577133888, 1.0E-12
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+}
+
+
+TEST_F(TestSingleSiteAlgorithmSpinSystem, 2DHeisenberg) {
+  auto dmpo_gen = MPOGenerator<GQTEN_Double, U1QN>(dsite_vec_6, qn0);
+  std::vector<std::pair<size_t, size_t>> nn_pairs = {
+      std::make_pair(0, 1),
+      std::make_pair(0, 2),
+      std::make_pair(1, 3),
+      std::make_pair(2, 3),
+      std::make_pair(2, 4),
+      std::make_pair(3, 5),
+      std::make_pair(4, 5)
+  };
+  for (auto &p : nn_pairs) {
+    dmpo_gen.AddTerm(1,   {dsz, dsz}, {p.first, p.second});
+    dmpo_gen.AddTerm(0.5, {dsp, dsm}, {p.first, p.second});
+    dmpo_gen.AddTerm(0.5, {dsm, dsp}, {p.first, p.second});
+  }
+  auto dmpo = dmpo_gen.Gen();
+
+  auto sweep_params = SweepParams(
+                          6,
+                          8, 8, 1.0E-9,
+                          LanczosParams(1.0E-7),
+                          {0.01,0.001,0.0001,0.00001}
+                      );
+
+  // Test direct product state initialization.
+  std::vector<size_t> stat_labs;
+  for (size_t i = 0; i < N; ++i) { stat_labs.push_back(i % 2); }
+  DirectStateInitMps(dmps, stat_labs);
+  dmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      dmps, dmpo, sweep_params,
+      -3.129385241572, 1.0E-12
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+
+  // Complex Hamiltonian
+  auto zmpo_gen = MPOGenerator<GQTEN_Complex, U1QN>(zsite_vec_6, qn0);
+  for (auto &p : nn_pairs) {
+    zmpo_gen.AddTerm(1,   {zsz, zsz}, {p.first, p.second});
+    zmpo_gen.AddTerm(0.5, {zsp, zsm}, {p.first, p.second});
+    zmpo_gen.AddTerm(0.5, {zsm, zsp}, {p.first, p.second});
+  }
+  auto zmpo = zmpo_gen.Gen();
+
+  sweep_params = SweepParams(
+                     6,
+                     8, 8, 1.0E-9,
+                     LanczosParams(1.0E-7),
+                     {0.01,0.001,0.0001,0.00001}
+                 );
+  DirectStateInitMps(zmps, stat_labs);
+  zmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      zmps, zmpo, sweep_params,
+      -3.129385241572, 1.0E-12
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+}
+
+
+TEST_F(TestSingleSiteAlgorithmSpinSystem, 2DKitaevSimpleCase) {
+  size_t Nx = 4;
+  size_t Ny = 2;
+  size_t N1 = Nx*Ny;
+  DSiteVec dsite_vec(N1, pb_out);
+  auto dmpo_gen = MPOGenerator<GQTEN_Double, U1QN>(dsite_vec, qn0);
+  for (int x = 0; x < Nx; ++x) {
+    for (int y = 0; y < Ny; ++y) {
+      if (x % 2 == 1) {
+        auto s0 = coors2idxHoneycomb(x, y, Nx, Ny);
+        auto s1 = coors2idxHoneycomb(x-1, y+1, Nx, Ny);
+        KeepOrder(s0, s1);
+        dmpo_gen.AddTerm(1, {dsz, dsz}, {s0, s1});
+      }
+    }
+  }
+  auto dmpo = dmpo_gen.Gen();
+
+  auto sweep_params = SweepParams(
+                          4,
+                          8, 8, 1.0E-4,
+                          LanczosParams(1.0E-10),
+                          {0.01,0.001,0.0001,0.00001}
+                      );
+  // Test extend direct product state random initialization.
+  std::vector<size_t> stat_labs1, stat_labs2;
+  for (size_t i = 0; i < N1; ++i) {
+    stat_labs1.push_back(i%2);
+    stat_labs2.push_back((i+1)%2);
+  }
+  auto dmps_8sites = DMPS(dsite_vec);
+  ExtendDirectRandomInitMps(dmps_8sites, {stat_labs1, stat_labs2}, 2);
+  dmps_8sites.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      dmps_8sites, dmpo, sweep_params,
+      -1.0, 1.0E-12
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+
+  // Complex Hamiltonian
+  ZSiteVec zsite_vec(N1, pb_out);
+  auto zmpo_gen = MPOGenerator<GQTEN_Complex, U1QN>(zsite_vec, qn0);
+  for (int x = 0; x < Nx; ++x) {
+    for (int y = 0; y < Ny; ++y) {
+      if (x % 2 == 1) {
+        auto s0 = coors2idxHoneycomb(x, y, Nx, Ny);
+        auto s1 = coors2idxHoneycomb(x-1, y+1, Nx, Ny);
+        KeepOrder(s0, s1);
+        zmpo_gen.AddTerm(1, {zsz, zsz}, {s0, s1});
+      }
+    }
+  }
+  auto zmpo = zmpo_gen.Gen();
+  auto zmps_8sites = ZMPS(zsite_vec);
+  ExtendDirectRandomInitMps(zmps_8sites, {stat_labs1, stat_labs2}, 2);
+  zmps_8sites.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      zmps_8sites, zmpo, sweep_params,
+      -1.0, 1.0E-12);
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+}
+
+
+TEST(TestSingleSiteAlgorithmNoSymmetrySpinSystem, 2DKitaevComplexCase) {
+  using TenElemType = GQTEN_Complex;
+  using Tensor = GQTensor<TenElemType, U1QN>;
+  //-------------Set quantum numbers-----------------
+  auto zero_div = U1QN({QNCard("N", U1QNVal(0))});
+  auto idx_out = IndexT(
+                     {QNSctT(U1QN({QNCard("N", U1QNVal(1))}), 2)},
+                     GQTenIndexDirType::OUT
+                 );
+  auto idx_in = InverseIndex(idx_out);
+  //--------------Single site operators-----------------
+  // define the structure of operators
+  auto sz = Tensor({idx_in, idx_out});
+  auto sx = Tensor({idx_in, idx_out});
+  auto sy = Tensor({idx_in, idx_out});
+  auto id = Tensor({idx_in, idx_out});
+  // define the contents of operators
+  sz({0, 0}) = GQTEN_Complex(0.5, 0);
+  sz({1, 1}) = GQTEN_Complex(-0.5, 0);
+  sx({0, 1}) = GQTEN_Complex(0.5, 0);
+  sx({1, 0}) = GQTEN_Complex(0.5, 0);
+  sy({0, 1}) = GQTEN_Complex(0, -0.5);
+  sy({1, 0}) = GQTEN_Complex(0, 0.5);
+  id({0, 0}) = GQTEN_Complex(1, 0);
+  id({1, 1}) = GQTEN_Complex(1, 0);
+  //---------------Generate the MPO-----------------
+  double J = -1.0;
+  double K = 1.0;
+  double Gm = 0.1;
+  double h = 0.1;
+  size_t Nx = 3, Ny = 4;
+  size_t N = Nx*Ny;
+  ZSiteVec site_vec(N, idx_out);
+  auto mpo_gen = MPOGenerator<TenElemType, U1QN>(site_vec, zero_div);
+  // H =   J * \Sigma_{<ij>} S_i*S_j
+  //       K * \Sigma_{<ij>,c-link} Sc_i*Sc_j
+  //		 Gm * \Sigma_{<ij>,c-link} Sa_i*Sb_j + Sb_i*Sa_j
+  //     - h * \Sigma_i{S^z}
+  for (int x = 0; x < Nx; ++x) {
+    for (int y = 0; y < Ny; ++y) {
+      // use the configuration '/|\' to traverse the square lattice
+      // single site operator
+      auto site0_num = coors2idx(x, y, Nx, Ny);
+      mpo_gen.AddTerm(-h, sz, site0_num);
+      mpo_gen.AddTerm(-h, sx, site0_num);
+      mpo_gen.AddTerm(-h, sy, site0_num);
+      // the '/' part: x-link
+      // note that x and y start from 0
+      if (y % 2 == 0) {
+        auto site0_num = coors2idx(x, y, Nx, Ny);
+        auto site1_num = coors2idx(x, y + 1, Nx, Ny);
+        std::cout << site0_num << " " << site1_num << std::endl;
+        mpo_gen.AddTerm(J,  sz, site0_num, sz, site1_num);
+        mpo_gen.AddTerm(J,  sx, site0_num, sx, site1_num);
+        mpo_gen.AddTerm(J,  sy, site0_num, sy, site1_num);
+        mpo_gen.AddTerm(K,  sx, site0_num, sx, site1_num);
+        mpo_gen.AddTerm(Gm, sz, site0_num, sy, site1_num);
+        mpo_gen.AddTerm(Gm, sy, site0_num, sz, site1_num);
+      }
+      // the '|' part: z-link
+      if (y % 2 == 1) {
+        auto site0_num = coors2idx(x, y, Nx, Ny);
+        auto site1_num = coors2idx(x, (y + 1) % Ny, Nx, Ny);
+        KeepOrder(site0_num, site1_num);
+        std::cout << site0_num << " " << site1_num << std::endl;
+        mpo_gen.AddTerm(J,  sz, site0_num, sz, site1_num);
+        mpo_gen.AddTerm(J,  sx, site0_num, sx, site1_num);
+        mpo_gen.AddTerm(J,  sy, site0_num, sy, site1_num);
+        mpo_gen.AddTerm(K,  sz, site0_num, sz, site1_num);
+        mpo_gen.AddTerm(Gm, sx, site0_num, sy, site1_num);
+        mpo_gen.AddTerm(Gm, sy, site0_num, sx, site1_num);
+      }
+      // the '\' part: y-link
+      // if (y % 2 == 1) {																	// torus
+      if ((y % 2 == 1)&&(x != Nx - 1)) {
+        auto site0_num = coors2idx(x, y, Nx, Ny);
+        auto site1_num = coors2idx(x + 1, y - 1, Nx, Ny);						// cylinder
+        KeepOrder(site0_num, site1_num);
+        std::cout << site0_num << " " << site1_num << std::endl;
+        mpo_gen.AddTerm(J,  sz, site0_num, sz, site1_num);
+        mpo_gen.AddTerm(J,  sx, site0_num, sx, site1_num);
+        mpo_gen.AddTerm(J,  sy, site0_num, sy, site1_num);
+        mpo_gen.AddTerm(K,  sy, site0_num, sy, site1_num);
+        mpo_gen.AddTerm(Gm, sz, site0_num, sx, site1_num);
+        mpo_gen.AddTerm(Gm, sx, site0_num, sz, site1_num);
+      }
+    }
+  }
+  auto mpo = mpo_gen.Gen();
+
+  FiniteMPS<TenElemType, U1QN> mps(site_vec);
+  std::vector<size_t> stat_labs(N);
+  auto was_up = false;
+  for (size_t i = 0; i < N; ++i) {
+    if (was_up) {
+      stat_labs[i] = 1;
+      was_up = false;
+    }
+    else if (!was_up) {
+      stat_labs[i] = 0;
+      was_up = true;
+    }
+  }
+  auto sweep_params = SweepParams(
+                          4,
+                          60, 60, 1.0E-4,
+                          LanczosParams(1.0E-10),
+                          {0.01,0.001,0.0001,0.00001}
+                      );
+  DirectStateInitMps(mps, stat_labs);
+  mps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(mps, mpo, sweep_params, -4.57509167674, 2.0E-10);
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+}
+
+
+// Test fermion models.
+struct TestSingleSiteAlgorithmTjSystem2U1Symm : public testing::Test {
+  size_t N = 4;
+  double t = 3.0;
+  double J = 1.0;
+  U1U1QN qn0 = U1U1QN({QNCard("N", U1QNVal(0)), QNCard("Sz", U1QNVal(0))});
+  IndexT2 pb_out = IndexT2({
+      QNSctT2(U1U1QN({QNCard("N", U1QNVal(1)), QNCard("Sz", U1QNVal( 1))}), 1),
+      QNSctT2(U1U1QN({QNCard("N", U1QNVal(1)), QNCard("Sz", U1QNVal(-1))}), 1),
+      QNSctT2(U1U1QN({QNCard("N", U1QNVal(0)), QNCard("Sz", U1QNVal( 0))}), 1)},
+      GQTenIndexDirType::OUT
+  );
+  IndexT2 pb_in = InverseIndex(pb_out);
+  DSiteVec2 dsite_vec_4 = DSiteVec2(N, pb_out);
+  ZSiteVec2 zsite_vec_4 = ZSiteVec2(N, pb_out);
+
+  DGQTensor2 df      = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dsz     = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dsp     = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dsm     = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dcup    = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dcdagup = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dcdn    = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dcdagdn = DGQTensor2({pb_in, pb_out});
+  DMPS2 dmps   = DMPS2(dsite_vec_4);
+
+  ZGQTensor2 zf      = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 zsz     = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 zsp     = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 zsm     = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 zcup    = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 zcdagup = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 zcdn    = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 zcdagdn = ZGQTensor2({pb_in, pb_out});
+  ZMPS2 zmps   = ZMPS2(zsite_vec_4);
+
+  void SetUp(void) {
+    df({0, 0})  = -1;
+    df({1, 1})  = -1;
+    df({2, 2})  = 1;
+    dsz({0, 0}) =  0.5;
+    dsz({1, 1}) = -0.5;
+    dsp({1, 0}) = 1;
+    dsm({0, 1}) = 1;
+    dcup({0, 2}) = 1;
+    dcdagup({2, 0}) = 1;
+    dcdn({1, 2}) = 1;
+    dcdagdn({2, 1}) = 1;
+
+    zf({0, 0})  = -1;
+    zf({1, 1})  = -1;
+    zf({2, 2})  = 1;
+    zsz({0, 0}) =  0.5;
+    zsz({1, 1}) = -0.5;
+    zsp({1, 0}) = 1;
+    zsm({0, 1}) = 1;
+    zcup({0, 2}) = 1;
+    zcdagup({2, 0}) = 1;
+    zcdn({1, 2}) = 1;
+    zcdagdn({2, 1}) = 1;
+  }
+};
+
+
+TEST_F(TestSingleSiteAlgorithmTjSystem2U1Symm, 1DCase) {
+  auto dmpo_gen = MPOGenerator<GQTEN_Double, U1U1QN>(dsite_vec_4, qn0);
+  for (size_t i = 0; i < N-1; ++i) {
+    dmpo_gen.AddTerm(-t, dcdagup, i, dcup, i+1, df);
+    dmpo_gen.AddTerm(-t, dcdagdn, i, dcdn, i+1, df);
+    dmpo_gen.AddTerm(-t, dcup, i, dcdagup, i+1, df);
+    dmpo_gen.AddTerm(-t, dcdn, i, dcdagdn, i+1, df);
+    dmpo_gen.AddTerm(J,   dsz, i, dsz, i+1);
+    dmpo_gen.AddTerm(J/2, dsp, i, dsm, i+1);
+    dmpo_gen.AddTerm(J/2, dsm, i, dsp, i+1);
+  }
+  auto dmpo = dmpo_gen.Gen();
+
+  auto sweep_params = SweepParams(
+                          11,
+                          8, 8, 1.0E-9,
+                          LanczosParams(1.0E-8, 20),
+                          {0.01,0.001,0.0001,0.00001}
+                      );
+  DirectStateInitMps(dmps, {2, 1, 2, 0});
+  dmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      dmps, dmpo, sweep_params,
+      -6.947478526233, 1.0E-10
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+
+  // Complex Hamiltonian
+  auto zmpo_gen = MPOGenerator<GQTEN_Complex, U1U1QN>(zsite_vec_4, qn0);
+  for (size_t i = 0; i < N-1; ++i) {
+    zmpo_gen.AddTerm(-t, zcdagup, i, zcup, i+1, zf);
+    zmpo_gen.AddTerm(-t, zcdagdn, i, zcdn, i+1, zf);
+    zmpo_gen.AddTerm(-t, zcup, i, zcdagup, i+1, zf);
+    zmpo_gen.AddTerm(-t, zcdn, i, zcdagdn, i+1, zf);
+    zmpo_gen.AddTerm(J,   zsz, i, zsz, i+1);
+    zmpo_gen.AddTerm(J/2, zsp, i, zsm, i+1);
+    zmpo_gen.AddTerm(J/2, zsm, i, zsp, i+1);
+  }
+  auto zmpo = zmpo_gen.Gen();
+  DirectStateInitMps(zmps, {2, 1, 2, 0});
+  zmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      zmps, zmpo, sweep_params,
+      -6.947478526233, 1.0E-10
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+}
+
+
+TEST_F(TestSingleSiteAlgorithmTjSystem2U1Symm, 2DCase) {
+  auto dmpo_gen = MPOGenerator<GQTEN_Double, U1U1QN>(dsite_vec_4, qn0);
+  std::vector<std::pair<int, int>> nn_pairs = {
+      std::make_pair(0, 1), 
+      std::make_pair(0, 2), 
+      std::make_pair(2, 3), 
+      std::make_pair(1, 3)};
+  for (auto &p : nn_pairs) {
+    dmpo_gen.AddTerm(-t, dcdagup, p.first, dcup, p.second, df);
+    dmpo_gen.AddTerm(-t, dcdagdn, p.first, dcdn, p.second, df);
+    dmpo_gen.AddTerm(-t, dcup, p.first, dcdagup, p.second, df);
+    dmpo_gen.AddTerm(-t, dcdn, p.first, dcdagdn, p.second, df);
+    dmpo_gen.AddTerm(J,   dsz, p.first, dsz, p.second);
+    dmpo_gen.AddTerm(J/2, dsp, p.first, dsm, p.second);
+    dmpo_gen.AddTerm(J/2, dsm, p.first, dsp, p.second);
+  }
+  auto dmpo = dmpo_gen.Gen();
+
+  auto sweep_params = SweepParams(
+                          10,
+                          8, 8, 1.0E-9,
+                          LanczosParams(1.0E-8, 20),
+                          {0.01,0.001,0.0001,0.00001}
+                      );
+
+  auto total_div = U1U1QN({QNCard("N", U1QNVal(N-2)), QNCard("Sz", U1QNVal(0))});
+  auto zero_div = U1U1QN({QNCard("N",  U1QNVal(0)), QNCard("Sz",   U1QNVal(0))});
+
+  // Direct product state initialization.
+  DirectStateInitMps(dmps, {2, 0, 1, 2});
+  dmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      dmps, dmpo, sweep_params,
+      -8.868563739680, 1.0E-10
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+
+  // Complex Hamiltonian
+  auto zmpo_gen = MPOGenerator<GQTEN_Complex, U1U1QN>(zsite_vec_4, qn0);
+  for (auto &p : nn_pairs) {
+    zmpo_gen.AddTerm(-t, zcdagup, p.first, zcup, p.second, zf);
+    zmpo_gen.AddTerm(-t, zcdagdn, p.first, zcdn, p.second, zf);
+    zmpo_gen.AddTerm(-t, zcup, p.first, zcdagup, p.second, zf);
+    zmpo_gen.AddTerm(-t, zcdn, p.first, zcdagdn, p.second, zf);
+    zmpo_gen.AddTerm(J,   zsz, p.first, zsz, p.second);
+    zmpo_gen.AddTerm(J/2, zsp, p.first, zsm, p.second);
+    zmpo_gen.AddTerm(J/2, zsm, p.first, zsp, p.second);
+  }
+  auto zmpo = zmpo_gen.Gen();
+  DirectStateInitMps(zmps, {2, 0, 1, 2});
+  zmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      zmps, zmpo, sweep_params,
+      -8.868563739680, 1.0E-10
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+}
+
+
+struct TestSingleSiteAlgorithmTjSystem1U1Symm : public testing::Test {
+  U1QN qn0 = U1QN({QNCard("N", U1QNVal(0))});
+  IndexT pb_out = IndexT({
+                      QNSctT(U1QN({QNCard("N", U1QNVal(1))}), 2),
+                      QNSctT(U1QN({QNCard("N", U1QNVal(0))}), 1)},
+                      GQTenIndexDirType::OUT
+                  );
+  IndexT pb_in = InverseIndex(pb_out);
+  ZGQTensor zf = ZGQTensor({pb_in, pb_out});
+  ZGQTensor zsz = ZGQTensor({pb_in, pb_out});
+  ZGQTensor zsp = ZGQTensor({pb_in, pb_out});
+  ZGQTensor zsm = ZGQTensor({pb_in, pb_out});
+  ZGQTensor zcup = ZGQTensor({pb_in, pb_out});
+  ZGQTensor zcdagup = ZGQTensor({pb_in, pb_out});
+  ZGQTensor zcdn = ZGQTensor({pb_in, pb_out});
+  ZGQTensor zcdagdn = ZGQTensor({pb_in, pb_out});
+  ZGQTensor zntot = ZGQTensor({pb_in, pb_out});
+  ZGQTensor zid = ZGQTensor({pb_in, pb_out});
+
+  void SetUp(void) {
+    zf({0, 0})  = -1;
+    zf({1, 1})  = -1;
+    zf({2, 2})  = 1;
+    zsz({0, 0}) =  0.5;
+    zsz({1, 1}) = -0.5;
+    zsp({0, 1}) = 1;
+    zsm({1, 0}) = 1;
+    zcup({2, 0}) = 1;
+    zcdagup({0, 2}) = 1;
+    zcdn({2, 1}) = 1;
+    zcdagdn({1, 2}) = 1;
+    zntot({0, 0}) = 1;
+    zntot({1, 1}) = 1;
+    zid({0,0})=1;
+    zid({1,1})=1;
+    zid({2,2})=1;
+  }
+};
+
+
+TEST_F(TestSingleSiteAlgorithmTjSystem1U1Symm, RashbaTermCase) {
+  double t = 3.0;
+  double J = 1.0;
+  double lamb = 0.03;
+  auto ilamb = GQTEN_Complex(0, lamb);
+  size_t Nx = 3;
+  size_t Ny = 2;
+  size_t Ntot = Nx * Ny;
+  char BCx = 'p';
+  char BCy = 'o';
+  ZSiteVec site_vec(Ntot, pb_out);
+  auto mpo_gen = MPOGenerator<GQTEN_Complex, U1QN>(site_vec, qn0);
+  for (int x = 0; x < Nx; ++x) {
+    for (int y = 0; y < Ny; ++y) {
+
+      if (!((BCx == 'o') && (x == Nx-1))) {
+        auto s0 = coors2idxSquare(x, y, Nx, Ny);
+        auto s1 = coors2idxSquare((x+1)%Nx, y, Nx, Ny);
+        KeepOrder(s0, s1);
+        std::cout << s0 << " " << s1 << std::endl;
+        mpo_gen.AddTerm(-t, zcdagup, s0, zcup, s1, zf);
+        mpo_gen.AddTerm(-t, zcdagdn, s0, zcdn, s1, zf);
+        mpo_gen.AddTerm(-t, zcup, s0, zcdagup, s1, zf);
+        mpo_gen.AddTerm(-t, zcdn, s0, zcdagdn, s1, zf);
+        mpo_gen.AddTerm(J,    zsz, s0, zsz, s1);
+        mpo_gen.AddTerm(J/2,  zsp, s0, zsm, s1);
+        mpo_gen.AddTerm(J/2,  zsm, s0, zsp, s1);
+        mpo_gen.AddTerm(-J/4, zntot, s0, zntot, s1);
+        // SO term
+        if (x != Nx-1) {
+          mpo_gen.AddTerm(lamb, zcdagup, s0, zcdn, s1, zf);
+          mpo_gen.AddTerm(lamb, zcup, s0, zcdagdn, s1, zf);
+          mpo_gen.AddTerm(-lamb, zcdagdn, s0, zcup, s1, zf);
+          mpo_gen.AddTerm(-lamb, zcdn, s0, zcdagup, s1, zf);
+        } else {    // At the boundary
+          mpo_gen.AddTerm(lamb, zcdn, s0, zcdagup, s1, zf);
+          mpo_gen.AddTerm(lamb, zcdagdn, s0, zcup, s1, zf);
+          mpo_gen.AddTerm(-lamb, zcup, s0, zcdagdn, s1, zf);
+          mpo_gen.AddTerm(-lamb, zcdagup, s0, zcdn, s1, zf);
+        }
+      }
+
+      if (!((BCy == 'o') && (y == Ny-1))) {
+        auto s0 = coors2idxSquare(x, y, Nx, Ny);
+        auto s2 = coors2idxSquare(x, (y+1)%Ny, Nx, Ny);
+        KeepOrder(s0, s2);
+        std::cout << s0 << " " << s2 << std::endl;
+        mpo_gen.AddTerm(-t, zcdagup, s0, zcup, s2, zf);
+        mpo_gen.AddTerm(-t, zcdagdn, s0, zcdn, s2, zf);
+        mpo_gen.AddTerm(-t, zcup, s0, zcdagup, s2, zf);
+        mpo_gen.AddTerm(-t, zcdn, s0, zcdagdn, s2, zf);
+        mpo_gen.AddTerm(J,    zsz, s0, zsz, s2);
+        mpo_gen.AddTerm(J/2,  zsp, s0, zsm, s2);
+        mpo_gen.AddTerm(J/2,  zsm, s0, zsp, s2);
+        mpo_gen.AddTerm(-J/4, zntot, s0, zntot, s2);
+        if (y != Ny-1) {
+          mpo_gen.AddTerm(ilamb, zcdagup, s0, zcdn, s2, zf);
+          mpo_gen.AddTerm(ilamb, zcdagdn, s0, zcup, s2, zf);
+          mpo_gen.AddTerm(-ilamb, zcup, s0, zcdagdn, s2, zf);
+          mpo_gen.AddTerm(-ilamb, zcdn, s0, zcdagup, s2, zf);
+        } else {    // At the boundary
+          mpo_gen.AddTerm(ilamb, zcup, s0, zcdagdn, s2, zf);
+          mpo_gen.AddTerm(ilamb, zcdn, s0, zcdagup, s2, zf);
+          mpo_gen.AddTerm(-ilamb, zcdagup, s0, zcdn, s2, zf);
+          mpo_gen.AddTerm(-ilamb, zcdagdn, s0, zcup, s2, zf);
+        }
+      }
+    }
+  }
+  auto mpo = mpo_gen.Gen();
+
+  auto sweep_params = SweepParams(
+                          8,
+                          30, 30, 1.0E-4,
+                          LanczosParams(1.0E-14, 100),
+                          {0.01,0.001,0.0001,0.00001}
+                      );
+  auto mps = ZMPS(site_vec);
+  DirectStateInitMps(mps, {0, 1, 0, 2, 0, 1});
+  mps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      mps, mpo, sweep_params,
+      -11.018692166942165, 1.0E-10
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+}
+
+
+struct TestSingleSiteAlgorithmHubbardSystem : public testing::Test {
+  size_t Nx = 2;
+  size_t Ny = 2;
+  size_t N = Nx * Ny;
+  double t0 = 1.0;
+  double t1 = 0.5;
+  double U = 2.0;
+
+  U1U1QN qn0 = U1U1QN({QNCard("Nup", U1QNVal(0)), QNCard("Ndn", U1QNVal(0))});
+  IndexT2 pb_out = IndexT2({
+      QNSctT2(U1U1QN({QNCard("Nup", U1QNVal(0)), QNCard("Ndn", U1QNVal(0))}), 1),
+      QNSctT2(U1U1QN({QNCard("Nup", U1QNVal(1)), QNCard("Ndn", U1QNVal(0))}), 1),
+      QNSctT2(U1U1QN({QNCard("Nup", U1QNVal(0)), QNCard("Ndn", U1QNVal(1))}), 1),
+      QNSctT2(U1U1QN({QNCard("Nup", U1QNVal(1)), QNCard("Ndn", U1QNVal(1))}), 1)},
+      GQTenIndexDirType::OUT
+  );
+  IndexT2 pb_in = InverseIndex(pb_out);
+  DSiteVec2 dsite_vec = DSiteVec2(N, pb_out);
+  ZSiteVec2 zsite_vec = ZSiteVec2(N, pb_out);
+
+  DGQTensor2 df       = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dnupdn   = DGQTensor2({pb_in, pb_out});    // n_up*n_dn
+  DGQTensor2 dadagupf = DGQTensor2({pb_in, pb_out});    // a^+_up*f
+  DGQTensor2 daup     = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dadagdn  = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dfadn    = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dnaupf   = DGQTensor2({pb_in, pb_out});    // -a_up*f
+  DGQTensor2 dadagup  = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dnadn    = DGQTensor2({pb_in, pb_out});
+  DGQTensor2 dfadagdn = DGQTensor2({pb_in, pb_out});    // f*a^+_dn
+  DMPS2 dmps = DMPS2(dsite_vec);
+
+  ZGQTensor2 zf       = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 znupdn   = ZGQTensor2({pb_in, pb_out});    // n_up*n_dn
+  ZGQTensor2 zadagupf = ZGQTensor2({pb_in, pb_out});    // a^+_up*f
+  ZGQTensor2 zaup     = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 zadagdn  = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 zfadn    = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 znaupf   = ZGQTensor2({pb_in, pb_out});    // -a_up*f
+  ZGQTensor2 zadagup  = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 znadn    = ZGQTensor2({pb_in, pb_out});
+  ZGQTensor2 zfadagdn = ZGQTensor2({pb_in, pb_out});    // f*a^+_dn
+  ZMPS2 zmps = ZMPS2(zsite_vec);
+
+  void SetUp(void) {
+    df({0, 0})  = 1;
+    df({1, 1})  = -1;
+    df({2, 2})  = -1;
+    df({3, 3})  = 1;
+
+    dnupdn({3, 3}) = 1;
+
+    dadagupf({1, 0}) = 1;
+    dadagupf({3, 2}) = -1;
+    daup({0, 1}) = 1;
+    daup({2, 3}) = 1;
+    dadagdn({2, 0}) = 1;
+    dadagdn({3, 1}) = 1;
+    dfadn({0, 2}) = 1;
+    dfadn({1, 3}) = -1;
+    dnaupf({0, 1}) = 1;
+    dnaupf({2, 3}) = -1;
+    dadagup({1, 0}) = 1;
+    dadagup({3, 2}) = 1;
+    dnadn({0, 2}) = -1;
+    dnadn({1, 3}) = -1;
+    dfadagdn({2, 0}) = -1;
+    dfadagdn({3, 1}) = 1;
+
+    zf({0, 0})  = 1;
+    zf({1, 1})  = -1;
+    zf({2, 2})  = -1;
+    zf({3, 3})  = 1;
+
+    znupdn({3, 3}) = 1;
+
+    zadagupf({1, 0}) = 1;
+    zadagupf({3, 2}) = -1;
+    zaup({0, 1}) = 1;
+    zaup({2, 3}) = 1;
+    zadagdn({2, 0}) = 1;
+    zadagdn({3, 1}) = 1;
+    zfadn({0, 2}) = 1;
+    zfadn({1, 3}) = -1;
+    znaupf({0, 1}) = 1;
+    znaupf({2, 3}) = -1;
+    zadagup({1, 0}) = 1;
+    zadagup({3, 2}) = 1;
+    znadn({0, 2}) = -1;
+    znadn({1, 3}) = -1;
+    zfadagdn({2, 0}) = -1;
+    zfadagdn({3, 1}) = 1;
+  }
+};
+
+
+TEST_F(TestSingleSiteAlgorithmHubbardSystem, 2Dcase) {
+  auto dmpo_gen = MPOGenerator<GQTEN_Double, U1U1QN>(dsite_vec, qn0);
+  for (int i = 0; i < Nx; ++i) {
+    for (int j = 0; j < Ny; ++j) {
+      auto s0 = coors2idxSquare(i, j, Nx, Ny);
+      dmpo_gen.AddTerm(U, dnupdn, s0);
+
+      if (i != Nx-1) {
+        auto s1 = coors2idxSquare(i+1, j, Nx, Ny);
+        std::cout << s0 << " " << s1 << std::endl;
+        dmpo_gen.AddTerm(1, -t0*dadagupf, s0, daup, s1, df);
+        dmpo_gen.AddTerm(1, -t0*dadagdn, s0, dfadn, s1, df);
+        dmpo_gen.AddTerm(1, dnaupf, s0, -t0*dadagup, s1, df);
+        dmpo_gen.AddTerm(1, dnadn, s0, -t0*dfadagdn, s1, df);
+      }
+      if (j != Ny-1) {
+        auto s1 = coors2idxSquare(i, j+1, Nx, Ny);
+        std::cout << s0 << " " << s1 << std::endl;
+        dmpo_gen.AddTerm(1, -t0*dadagupf, s0, daup, s1, df);
+        dmpo_gen.AddTerm(1, -t0*dadagdn, s0, dfadn, s1, df);
+        dmpo_gen.AddTerm(1, dnaupf, s0, -t0*dadagup, s1, df);
+        dmpo_gen.AddTerm(1, dnadn, s0, -t0*dfadagdn, s1, df);
+      }
+
+      if (j != Ny-1) {
+        if (i != 0) {
+          auto s2 = coors2idxSquare(i-1, j+1, Nx, Ny);
+          auto temp_s0 = s0;
+          KeepOrder(temp_s0, s2);
+          std::cout << temp_s0 << " " << s2 << std::endl;
+          dmpo_gen.AddTerm(1, -t1*dadagupf, temp_s0, daup, s2, df);
+          dmpo_gen.AddTerm(1, -t1*dadagdn, temp_s0, dfadn, s2, df);
+          dmpo_gen.AddTerm(1, dnaupf, temp_s0, -t1*dadagup, s2, df);
+          dmpo_gen.AddTerm(1, dnadn, temp_s0, -t1*dfadagdn, s2, df);
+        }
+        if (i != Nx-1) {
+          auto s2 = coors2idxSquare(i+1, j+1, Nx, Ny);
+          auto temp_s0 = s0;
+          KeepOrder(temp_s0, s2);
+          std::cout << temp_s0 << " " << s2 << std::endl;
+          dmpo_gen.AddTerm(1, -t1*dadagupf, temp_s0, daup, s2, df);
+          dmpo_gen.AddTerm(1, -t1*dadagdn, temp_s0, dfadn, s2, df);
+          dmpo_gen.AddTerm(1, dnaupf, temp_s0, -t1*dadagup, s2, df);
+          dmpo_gen.AddTerm(1, dnadn, temp_s0, -t1*dfadagdn, s2, df);
+        }
+      }
+    }
+  }
+  auto dmpo = dmpo_gen.Gen();
+
+  auto sweep_params = SweepParams(
+                          10,
+                          16, 16, 1.0E-9,
+                          LanczosParams(1.0E-8, 20),
+                          {0.1, 0.01,0.001}
+                      );
+  auto qn0 = U1U1QN({QNCard("Nup", U1QNVal(0)), QNCard("Ndn", U1QNVal(0))});
+  std::vector<size_t> stat_labs(N);
+  for (size_t i = 0; i < N; ++i) { stat_labs[i] = (i % 2 == 0 ? 1 : 2); }
+  DirectStateInitMps(dmps, stat_labs);
+  dmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      dmps, dmpo, sweep_params,
+      -2.828427124746, 1.0E-10
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+
+  // Complex Hamiltonian
+  auto zmpo_gen = MPOGenerator<GQTEN_Complex, U1U1QN>(zsite_vec, qn0);
+  for (int i = 0; i < Nx; ++i) {
+    for (int j = 0; j < Ny; ++j) {
+      auto s0 = coors2idxSquare(i, j, Nx, Ny);
+      zmpo_gen.AddTerm(U, znupdn, s0);
+
+      if (i != Nx-1) {
+        auto s1 = coors2idxSquare(i+1, j, Nx, Ny);
+        std::cout << s0 << " " << s1 << std::endl;
+        zmpo_gen.AddTerm(-t0, zadagupf, s0, zaup, s1, zf);
+        zmpo_gen.AddTerm(-t0, zadagdn, s0, zfadn, s1, zf);
+        zmpo_gen.AddTerm(-t0, znaupf, s0, zadagup, s1, zf);
+        zmpo_gen.AddTerm(-t0, znadn, s0, zfadagdn, s1, zf);
+      }
+      if (j != Ny-1) {
+        auto s1 = coors2idxSquare(i, j+1, Nx, Ny);
+        std::cout << s0 << " " << s1 << std::endl;
+        zmpo_gen.AddTerm(-t0, zadagupf, s0, zaup, s1, zf);
+        zmpo_gen.AddTerm(-t0, zadagdn, s0, zfadn, s1, zf);
+        zmpo_gen.AddTerm(-t0, znaupf, s0, zadagup, s1, zf);
+        zmpo_gen.AddTerm(-t0, znadn, s0, zfadagdn, s1, zf);
+      }
+
+      if (j != Ny-1) {
+        if (i != 0) {
+          auto s2 = coors2idxSquare(i-1, j+1, Nx, Ny);
+          auto temp_s0 = s0;
+          KeepOrder(temp_s0, s2);
+          std::cout << temp_s0 << " " << s2 << std::endl;
+          zmpo_gen.AddTerm(-t1, zadagupf, temp_s0, zaup, s2, zf);
+          zmpo_gen.AddTerm(-t1, zadagdn, temp_s0, zfadn, s2, zf);
+          zmpo_gen.AddTerm(-t1, znaupf, temp_s0, zadagup, s2, zf);
+          zmpo_gen.AddTerm(-t1, znadn, temp_s0, zfadagdn, s2, zf);
+        }
+        if (i != Nx-1) {
+          auto s2 = coors2idxSquare(i+1, j+1, Nx, Ny);
+          auto temp_s0 = s0;
+          KeepOrder(temp_s0, s2);
+          std::cout << temp_s0 << " " << s2 << std::endl;
+          zmpo_gen.AddTerm(-t1, zadagupf, temp_s0, zaup, s2, zf);
+          zmpo_gen.AddTerm(-t1, zadagdn, temp_s0, zfadn, s2, zf);
+          zmpo_gen.AddTerm(-t1, znaupf, temp_s0, zadagup, s2, zf);
+          zmpo_gen.AddTerm(-t1, znadn, temp_s0, zfadagdn, s2, zf);
+        }
+      }
+    }
+  }
+  auto zmpo = zmpo_gen.Gen();
+  DirectStateInitMps(zmps, stat_labs);
+  zmps.Dump(sweep_params.mps_path, true);
+  RunTestSingleSiteAlgorithmCase(
+      zmps, zmpo, sweep_params,
+      -2.828427124746, 1.0E-10
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+}
+
+
+// Test non-uniform local Hilbert spaces system.
+// Kondo insulator, ref 10.1103/PhysRevB.97.245119,
+struct TestKondoInsulatorSystem : public testing::Test {
+  size_t Nx = 4;
+  size_t N = 2 * Nx;
+  double t = 0.25;
+  double Jk = 1.0;
+  double Jz = 0.5;
+
+  U1QN qn0 = U1QN({QNCard("Sz", U1QNVal(0))});
+  IndexT pb_outE = IndexT(
+                       {QNSctT(U1QN({QNCard("Sz", U1QNVal(0))}), 4)},
+                       GQTenIndexDirType::OUT
+                   );    // extended electron
+  IndexT pb_outL = IndexT(
+                       {QNSctT(U1QN({QNCard("Sz", U1QNVal(0))}), 2)},
+                       GQTenIndexDirType::OUT
+                   );    // localized electron
+  IndexT pb_inE = InverseIndex(pb_outE);
+  IndexT pb_inL = InverseIndex(pb_outL);
+
+  DGQTensor sz = DGQTensor({pb_inE, pb_outE});
+  DGQTensor sp = DGQTensor({pb_inE, pb_outE});
+  DGQTensor sm = DGQTensor({pb_inE, pb_outE});
+  DGQTensor bupcF =DGQTensor({pb_inE, pb_outE});
+  DGQTensor bupaF = DGQTensor({pb_inE, pb_outE});
+  DGQTensor Fbdnc = DGQTensor({pb_inE, pb_outE});
+  DGQTensor Fbdna = DGQTensor({pb_inE, pb_outE});
+  DGQTensor bupc =DGQTensor({pb_inE, pb_outE});
+  DGQTensor bupa = DGQTensor({pb_inE, pb_outE});
+  DGQTensor bdnc = DGQTensor({pb_inE, pb_outE});
+  DGQTensor bdna = DGQTensor({pb_inE, pb_outE});
+
+  DGQTensor Sz =DGQTensor({pb_inL, pb_outL});
+  DGQTensor Sp =DGQTensor({pb_inL, pb_outL});
+  DGQTensor Sm =DGQTensor({pb_inL, pb_outL});
+
+  std::vector<IndexT> pb_set = std::vector<IndexT>(N);
+
+  void SetUp(void) {
+    sz({0,0}) = 0.5;  sz({1,1}) = -0.5;
+    sp({0,1}) = 1.0;
+    sm({1,0}) = 1.0;
+    bupcF({2,1}) = -1;  bupcF({0,3}) = 1;
+    Fbdnc({2,0}) = 1;   Fbdnc({1,3}) = -1;
+    bupaF({1,2}) = 1;   bupaF({3,0}) = -1;
+    Fbdna({0,2}) = -1;  Fbdna({3,1}) = 1;
+
+    bupc({2,1}) = 1;  bupc({0,3}) = 1;
+    bdnc({2,0}) = 1;  bdnc({1,3}) = 1;
+    bupa({1,2}) = 1;  bupa({3,0}) = 1;
+    bdna({0,2}) = 1;  bdna({3,1}) = 1;
+
+    Sz({0,0}) = 0.5;  Sz({1,1}) = -0.5;
+    Sp({0,1}) = 1.0;
+    Sm({1,0}) = 1.0;
+
+    for(size_t i = 0; i < N; ++i){
+      if(i%2==0) pb_set[i] = pb_outE;   // even site is extended electron
+      if(i%2==1) pb_set[i] = pb_outL;   // odd site is localized electron
+    }
+  }
+};
+
+
+TEST_F(TestKondoInsulatorSystem, doublechain) {
+  auto dsite_vec = DSiteVec(pb_set);
+  auto dmps = DMPS(dsite_vec);
+  auto dmpo_gen = MPOGenerator<GQTEN_Double, U1QN>(dsite_vec, qn0);
+  for (size_t i = 0; i < N-2; i=i+2){
+    dmpo_gen.AddTerm(-t, bupcF, i, bupa, i+2);
+    dmpo_gen.AddTerm(-t, bdnc, i, Fbdna, i+2);
+    dmpo_gen.AddTerm( t, bupaF, i, bupc, i+2);
+    dmpo_gen.AddTerm( t, bdna, i, Fbdnc, i+2);
+    dmpo_gen.AddTerm(Jz, Sz, i+1, Sz, i+3);
+  }
+  for (size_t i = 0; i < N; i=i+2){
+    dmpo_gen.AddTerm(Jk, sz, i, Sz, i+1);
+    dmpo_gen.AddTerm(Jk/2, sp, i, Sm, i+1);
+    dmpo_gen.AddTerm(Jk/2, sm, i, Sp, i+1);
+  }
+  auto dmpo = dmpo_gen.Gen();
+
+  auto sweep_params = SweepParams(
+    5,
+    64, 64, 1.0E-9,
+    LanczosParams(1.0E-8, 20),
+    {0.01, 0.001}
+  );
+
+  std::vector<size_t> stat_labs;
+  for (size_t i = 0; i < N; ++i) { stat_labs.push_back(i % 2); }
+  DirectStateInitMps(dmps, stat_labs);
+  dmps.Dump(sweep_params.mps_path, true);
+
+  RunTestSingleSiteAlgorithmCase(
+      dmps, dmpo, sweep_params,
+      -3.180025784229132, 1.0E-10
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+}
+
+
+
+// Electron-phonon interaction Holstein chain, ref 10.1103/PhysRevB.57.6376
+struct TestSingleSiteAlgorithmElectronPhononSystem : public testing::Test {
+  unsigned L = 4;           // The number of electron
+  unsigned Np = 3;          // per electron has Np pseudosite
+  double t = 1;         // electron hopping
+  double g = 1;         // electron-phonon interaction
+  double U = 8;         // Hubbard U
+  double omega = 5;     // phonon on-site potential
+  unsigned N = (1+Np)*L;     // The length of the mps/mpo
+
+  U1U1QN qn0 = U1U1QN({QNCard("N", U1QNVal(0)), QNCard("Sz", U1QNVal(0))});
+  //Fermion(electron)
+  IndexT2 pb_outF = IndexT2({
+                               QNSctT2(U1U1QN({QNCard("N", U1QNVal(2)), QNCard("Sz", U1QNVal(0))}), 1),
+                               QNSctT2(U1U1QN({QNCard("N", U1QNVal(1)), QNCard("Sz", U1QNVal(1))}), 1),
+                               QNSctT2(U1U1QN({QNCard("N", U1QNVal(1)), QNCard("Sz", U1QNVal(-1))}), 1),
+                               QNSctT2(U1U1QN({QNCard("S", U1QNVal(0)), QNCard("Sz", U1QNVal(0))}), 1)},
+                           GQTenIndexDirType::OUT
+  );
+  IndexT2 pb_inF = InverseIndex(pb_outF);
+  //Boson(Phonon)
+  IndexT2 pb_outB = IndexT2({QNSctT2(qn0,2)}, GQTenIndexDirType::OUT);
+  IndexT2 pb_inB = InverseIndex(pb_outB);
+
+  //ZSiteVec2 zsite_vec;
+
+  DGQTensor2 nf     = DGQTensor2({pb_inF, pb_outF}); //fermion number
+  DGQTensor2 bupcF  = DGQTensor2({pb_inF,pb_outF});
+  DGQTensor2 bupaF  = DGQTensor2({pb_inF,pb_outF});
+  DGQTensor2 Fbdnc  = DGQTensor2({pb_inF,pb_outF});
+  DGQTensor2 Fbdna  = DGQTensor2({pb_inF,pb_outF});
+  DGQTensor2 bupc   = DGQTensor2({pb_inF,pb_outF});
+  DGQTensor2 bupa   = DGQTensor2({pb_inF,pb_outF});
+  DGQTensor2 bdnc   = DGQTensor2({pb_inF,pb_outF});
+  DGQTensor2 bdna   = DGQTensor2({pb_inF,pb_outF});
+  DGQTensor2 Uterm  = DGQTensor2({pb_inF,pb_outF}); // Hubbard Uterm, nup*ndown
+
+  DGQTensor2 a      =   DGQTensor2({pb_inB, pb_outB}); //bosonic annihilation
+  DGQTensor2 adag   =   DGQTensor2({pb_inB, pb_outB}); //bosonic creation
+  DGQTensor2 P1    =   DGQTensor2({pb_inB, pb_outB}); // the number of phonon
+  DGQTensor2 idB    =   DGQTensor2({pb_inB, pb_outB}); // bosonic identity
+  DGQTensor2 P0     =   DGQTensor2({pb_inB, pb_outB});
+
+  std::vector<IndexT2> index_set = std::vector<IndexT2>(N);
+
+
+  void SetUp(void) {
+    nf({0,0}) = 2;  nf({1,1}) = 1;  nf({2,2}) = 1;
+
+    bupcF({0,2}) = -1;  bupcF({1,3}) = 1;
+    Fbdnc({0,1}) = 1;   Fbdnc({2,3}) = -1;
+    bupaF({2,0}) = 1;   bupaF({3,1}) = -1;
+    Fbdna({1,0}) = -1;  Fbdna({3,2}) = 1;
+
+    bupc({0,2}) = 1;    bupc({1,3}) = 1;
+    bdnc({0,1}) = 1;    bdnc({2,3}) = 1;
+    bupa({2,0}) = 1;    bupa({3,1}) = 1;
+    bdna({1,0}) = 1;    bdna({3,2}) = 1;
+
+    Uterm({0,0}) = 1;
+
+    adag({0,1}) = 1;
+    a({1,0}) = 1;
+    P1({0,0}) = 1;
+    idB({0,0}) = 1; idB({1,1}) = 1;
+    P0 = idB+(-P1);
+    for(size_t i =0; i < N; ++i){
+      if(i%(Np+1)==0) index_set[i] = pb_outF; // even site is fermion
+      else index_set[i] = pb_outB; // odd site is boson
+    }
+  }
+};
+
+TEST_F(TestSingleSiteAlgorithmElectronPhononSystem, holsteinchain) {
+  DSiteVec2 dsite_vec = DSiteVec2(index_set);
+  auto dmpo_gen = MPOGenerator<GQTEN_Double, U1U1QN>(dsite_vec, qn0);
+  for (int i = 0; i < N-Np-1; i=i+Np+1) {
+    dmpo_gen.AddTerm(-t, bupcF, i, bupa,  i+Np+1);
+    dmpo_gen.AddTerm(-t, bdnc,  i, Fbdna, i+Np+1);
+    dmpo_gen.AddTerm( t, bupaF, i, bupc,  i+Np+1);
+    dmpo_gen.AddTerm( t, bdna,  i, Fbdnc, i+Np+1);
+  }
+  for (unsigned long i = 0; i < N; i=i+Np+1) {
+    dmpo_gen.AddTerm(U, Uterm, i);
+    for(unsigned long j = 0; j < Np; ++j) {
+      dmpo_gen.AddTerm(omega, (double)(pow(2,j))*P1, i+j+1);
+    }
+    dmpo_gen.AddTerm(2*g, {nf,  a,      a,    adag},                  {i, i+1,  i+2,  i+3});
+    dmpo_gen.AddTerm(2*g, {nf,  adag,   adag, a},                     {i, i+1,  i+2,  i+3});
+    dmpo_gen.AddTerm(g,   {nf,  a,      adag, sqrt(2)*P0+sqrt(6)*P1}, {i, i+1,  i+2,  i+3});
+    dmpo_gen.AddTerm(g,   {nf,  adag,   a,    sqrt(2)*P0+sqrt(6)*P1}, {i, i+1,  i+2,  i+3});
+    dmpo_gen.AddTerm(g,   {nf,  a+adag, P1,   sqrt(3)*P0+sqrt(7)*P1}, {i, i+1,  i+2,  i+3});
+    dmpo_gen.AddTerm(g,   {nf,  a+adag, P0,   P0+sqrt(5)*P1},         {i, i+1,  i+2,  i+3});
+  }
+
+  auto dmpo = dmpo_gen.Gen();
+  DMPS2 dmps = DMPS2(dsite_vec);
+  std::vector<unsigned long> stat_labs(N,0);
+  int qn_label = 1;
+  for (int i = 0; i < N; i=i+Np+1) {
+    stat_labs[i] = qn_label;
+    qn_label=3-qn_label;
+  }
+  DirectStateInitMps(dmps, stat_labs);
+  auto sweep_params = SweepParams(5,
+     256, 256, 1.0E-10,
+     LanczosParams(1.0E-7),
+      {0.1,0.01,0.001,0.0001,0.00001}
+  );
+  dmps.Dump(sweep_params.mps_path, true);
+
+  RunTestSingleSiteAlgorithmCase(
+      dmps, dmpo, sweep_params,
+      -1.9363605088186260 , 1.0E-8
+  );
+  RemoveFolder(sweep_params.mps_path);
+  RemoveFolder(sweep_params.temp_path);
+}

--- a/tests/test_algorithm/test_two_site_update_finite_vmps.cc
+++ b/tests/test_algorithm/test_two_site_update_finite_vmps.cc
@@ -146,7 +146,7 @@ TEST_F(TestTwoSiteAlgorithmSpinSystem, 1DIsing) {
                       );
   std::vector<size_t> stat_labs;
   for (size_t i = 0; i < N; ++i) { stat_labs.push_back(i % 2); }
-  DirectStateInitMps(dmps, stat_labs, qn0);
+  DirectStateInitMps(dmps, stat_labs);
   dmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(dmps, dmpo, sweep_params, -0.25*(N-1), 1.0E-10);
 
@@ -175,7 +175,7 @@ TEST_F(TestTwoSiteAlgorithmSpinSystem, 1DIsing) {
                      1, 10, 1.0E-5,
                      LanczosParams(1.0E-7)
                  );
-  DirectStateInitMps(zmps, stat_labs, qn0);
+  DirectStateInitMps(zmps, stat_labs);
   zmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(zmps, zmpo, sweep_params, -0.25*(N-1), 1.0E-10);
 
@@ -205,7 +205,7 @@ TEST_F(TestTwoSiteAlgorithmSpinSystem, 1DHeisenberg) {
                       );
   std::vector<size_t> stat_labs;
   for (size_t i = 0; i < N; ++i) { stat_labs.push_back(i % 2); }
-  DirectStateInitMps(dmps, stat_labs, qn0);
+  DirectStateInitMps(dmps, stat_labs);
   dmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       dmps, dmpo, sweep_params,
@@ -235,7 +235,7 @@ TEST_F(TestTwoSiteAlgorithmSpinSystem, 1DHeisenberg) {
                      8, 8, 1.0E-9,
                      LanczosParams(1.0E-7)
                  );
-  DirectStateInitMps(zmps, stat_labs, qn0);
+  DirectStateInitMps(zmps, stat_labs);
   zmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       zmps, zmpo, sweep_params,
@@ -273,7 +273,7 @@ TEST_F(TestTwoSiteAlgorithmSpinSystem, 2DHeisenberg) {
   // Test direct product state initialization.
   std::vector<size_t> stat_labs;
   for (size_t i = 0; i < N; ++i) { stat_labs.push_back(i % 2); }
-  DirectStateInitMps(dmps, stat_labs, qn0);
+  DirectStateInitMps(dmps, stat_labs);
   dmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       dmps, dmpo, sweep_params,
@@ -296,7 +296,7 @@ TEST_F(TestTwoSiteAlgorithmSpinSystem, 2DHeisenberg) {
                      8, 8, 1.0E-9,
                      LanczosParams(1.0E-7)
                  );
-  DirectStateInitMps(zmps, stat_labs, qn0);
+  DirectStateInitMps(zmps, stat_labs);
   zmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       zmps, zmpo, sweep_params,
@@ -337,7 +337,7 @@ TEST_F(TestTwoSiteAlgorithmSpinSystem, 2DKitaevSimpleCase) {
     stat_labs2.push_back((i+1)%2);
   }
   auto dmps_8sites = DMPS(dsite_vec);
-  ExtendDirectRandomInitMps(dmps_8sites, {stat_labs1, stat_labs2}, qn0, 2);
+  ExtendDirectRandomInitMps(dmps_8sites, {stat_labs1, stat_labs2}, 2);
   dmps_8sites.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       dmps_8sites, dmpo, sweep_params,
@@ -361,7 +361,7 @@ TEST_F(TestTwoSiteAlgorithmSpinSystem, 2DKitaevSimpleCase) {
   }
   auto zmpo = zmpo_gen.Gen();
   auto zmps_8sites = ZMPS(zsite_vec);
-  ExtendDirectRandomInitMps(zmps_8sites, {stat_labs1, stat_labs2}, qn0, 2);
+  ExtendDirectRandomInitMps(zmps_8sites, {stat_labs1, stat_labs2}, 2);
   zmps_8sites.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       zmps_8sites, zmpo, sweep_params,
@@ -479,7 +479,7 @@ TEST(TestTwoSiteAlgorithmNoSymmetrySpinSystem, 2DKitaevComplexCase) {
                           60, 60, 1.0E-4,
                           LanczosParams(1.0E-10)
                       );
-  DirectStateInitMps(mps, stat_labs, zero_div);
+  DirectStateInitMps(mps, stat_labs);
   mps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(mps, mpo, sweep_params, -4.57509167674, 2.0E-10);
   RemoveFolder(sweep_params.mps_path);
@@ -569,7 +569,7 @@ TEST_F(TestTwoSiteAlgorithmTjSystem2U1Symm, 1DCase) {
                           8, 8, 1.0E-9,
                           LanczosParams(1.0E-8, 20)
                       );
-  DirectStateInitMps(dmps, {2, 1, 2, 0}, qn0);
+  DirectStateInitMps(dmps, {2, 1, 2, 0});
   dmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       dmps, dmpo, sweep_params,
@@ -590,7 +590,7 @@ TEST_F(TestTwoSiteAlgorithmTjSystem2U1Symm, 1DCase) {
     zmpo_gen.AddTerm(J/2, zsm, i, zsp, i+1);
   }
   auto zmpo = zmpo_gen.Gen();
-  DirectStateInitMps(zmps, {2, 1, 2, 0}, qn0);
+  DirectStateInitMps(zmps, {2, 1, 2, 0});
   zmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       zmps, zmpo, sweep_params,
@@ -629,7 +629,7 @@ TEST_F(TestTwoSiteAlgorithmTjSystem2U1Symm, 2DCase) {
   auto zero_div = U1U1QN({QNCard("N",  U1QNVal(0)), QNCard("Sz",   U1QNVal(0))});
 
   // Direct product state initialization.
-  DirectStateInitMps(dmps, {2, 0, 1, 2}, zero_div);
+  DirectStateInitMps(dmps, {2, 0, 1, 2});
   dmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       dmps, dmpo, sweep_params,
@@ -650,7 +650,7 @@ TEST_F(TestTwoSiteAlgorithmTjSystem2U1Symm, 2DCase) {
     zmpo_gen.AddTerm(J/2, zsm, p.first, zsp, p.second);
   }
   auto zmpo = zmpo_gen.Gen();
-  DirectStateInitMps(zmps, {2, 0, 1, 2}, zero_div);
+  DirectStateInitMps(zmps, {2, 0, 1, 2});
   zmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       zmps, zmpo, sweep_params,
@@ -778,7 +778,7 @@ TEST_F(TestTwoSiteAlgorithmTjSystem1U1Symm, RashbaTermCase) {
                           LanczosParams(1.0E-14, 100)
                       );
   auto mps = ZMPS(site_vec);
-  DirectStateInitMps(mps, {0, 1, 0, 2, 0, 1}, qn0);
+  DirectStateInitMps(mps, {0, 1, 0, 2, 0, 1});
   mps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       mps, mpo, sweep_params,
@@ -943,7 +943,7 @@ TEST_F(TestTwoSiteAlgorithmHubbardSystem, 2Dcase) {
   auto qn0 = U1U1QN({QNCard("Nup", U1QNVal(0)), QNCard("Ndn", U1QNVal(0))});
   std::vector<size_t> stat_labs(N);
   for (size_t i = 0; i < N; ++i) { stat_labs[i] = (i % 2 == 0 ? 1 : 2); }
-  DirectStateInitMps(dmps, stat_labs, qn0);
+  DirectStateInitMps(dmps, stat_labs);
   dmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       dmps, dmpo, sweep_params,
@@ -1001,7 +1001,7 @@ TEST_F(TestTwoSiteAlgorithmHubbardSystem, 2Dcase) {
     }
   }
   auto zmpo = zmpo_gen.Gen();
-  DirectStateInitMps(zmps, stat_labs, qn0);
+  DirectStateInitMps(zmps, stat_labs);
   zmps.Dump(sweep_params.mps_path, true);
   RunTestTwoSiteAlgorithmCase(
       zmps, zmpo, sweep_params,
@@ -1103,7 +1103,7 @@ TEST_F(TestKondoInsulatorSystem, doublechain) {
 
   std::vector<size_t> stat_labs;
   for (size_t i = 0; i < N; ++i) { stat_labs.push_back(i % 2); }
-  DirectStateInitMps(dmps, stat_labs, qn0);
+  DirectStateInitMps(dmps, stat_labs);
   dmps.Dump(sweep_params.mps_path, true);
 
   RunTestTwoSiteAlgorithmCase(

--- a/tests/test_case_params_parser.cc
+++ b/tests/test_case_params_parser.cc
@@ -26,6 +26,7 @@ struct CustomCaseParamsParser : public CaseParamsParserBasic {
     case_char = ParseChar("Char");
     case_str = ParseStr("String");
     case_bool = ParseBool("Boolean");
+    case_double_vec = ParseDoubleVec("DoubleVec");
   }
 
   int case_int;
@@ -33,6 +34,7 @@ struct CustomCaseParamsParser : public CaseParamsParserBasic {
   char case_char;
   std::string case_str;
   bool case_bool;
+  std::vector<double> case_double_vec;
 };
 
 
@@ -43,6 +45,7 @@ TEST(TestCaseParamsParser, Case1) {
   EXPECT_EQ(params.case_char, 'c');
   EXPECT_EQ(params.case_str, "string");
   EXPECT_EQ(params.case_bool, false);
+  EXPECT_EQ(params.case_double_vec, std::vector<double>({0.1, 0.02, 0.003}));
 }
 
 

--- a/tests/test_one_dim_tn/test_finite_mps/test_finite_mps.cc
+++ b/tests/test_one_dim_tn/test_finite_mps/test_finite_mps.cc
@@ -74,9 +74,12 @@ void CheckIsIdTen(const TenT &t) {
   EXPECT_EQ(shape.size(), 2);
   EXPECT_EQ(shape[0], shape[1]);
   for (size_t i = 0; i < shape[0]; ++i) {
-    for (size_t j = 0; j < shape[1]; ++j){
-      if(i==j)EXPECT_NEAR(t(i, i), 1.0, 1E-15);
-      else EXPECT_NEAR(t(i, j), 0.0, 1E-15);
+    for (size_t j = 0; j < shape[1]; ++j) {
+      if (i == j) {
+        EXPECT_NEAR(t(i, j), 1.0, 1E-15);
+      } else {
+        EXPECT_NEAR(t(i, j), 0.0, 1E-15);
+      }
     }
   }
 }
@@ -85,7 +88,8 @@ void CheckIsIdTen(const TenT &t) {
 void CheckMPSTenCanonical(
     const MPST &mps,
     const size_t i,
-    const int center) {
+    const int center
+) {
   std::vector<std::vector<size_t>> ctrct_leg_idxs;
   if (i < center) {
     ctrct_leg_idxs = {{0, 1}, {0, 1}};

--- a/tests/test_one_dim_tn/test_finite_mps/test_finite_mps.cc
+++ b/tests/test_one_dim_tn/test_finite_mps/test_finite_mps.cc
@@ -32,6 +32,7 @@ struct TestMPS : public testing::Test {
   QNT qn0 = QNT({QNCard("N", U1QNVal(0))});
   QNT qn1 = QNT({QNCard("N", U1QNVal(1))});
   QNT qn2 = QNT({QNCard("N", U1QNVal(2))});
+  IndexT vb0_in = IndexT({QNSctT(qn0, 1)}, IN);
   IndexT pb_out = IndexT({QNSctT(qn0, 1), QNSctT(qn1, 1)}, OUT);
   IndexT vb01_out = IndexT({QNSctT(qn0, 1), QNSctT(qn1, 1)}, OUT);
   IndexT vb01_in = InverseIndex(vb01_out);
@@ -40,11 +41,12 @@ struct TestMPS : public testing::Test {
                         OUT
                     );
   IndexT vb012_in = InverseIndex(vb012_out);
-  Tensor t0 = Tensor({pb_out, vb01_out});
+  IndexT vb0_out = InverseIndex(vb0_in);
+  Tensor t0 = Tensor({vb0_in, pb_out, vb01_out});
   Tensor t1 = Tensor({vb01_in, pb_out, vb012_out});
   Tensor t2 = Tensor({vb012_in, pb_out, vb012_out});
   Tensor t3 = Tensor({vb012_in, pb_out, vb01_out});
-  Tensor t4 = Tensor({vb01_in, pb_out});
+  Tensor t4 = Tensor({vb01_in, pb_out, vb0_out});
 
   SiteVecT site_vec = SiteVecT(5, pb_out);
 
@@ -72,7 +74,10 @@ void CheckIsIdTen(const TenT &t) {
   EXPECT_EQ(shape.size(), 2);
   EXPECT_EQ(shape[0], shape[1]);
   for (size_t i = 0; i < shape[0]; ++i) {
-    EXPECT_NEAR(t(i, i), 1.0, 1E-15);
+    for (size_t j = 0; j < shape[1]; ++j){
+      if(i==j)EXPECT_NEAR(t(i, i), 1.0, 1E-15);
+      else EXPECT_NEAR(t(i, j), 0.0, 1E-15);
+    }
   }
 }
 
@@ -83,17 +88,9 @@ void CheckMPSTenCanonical(
     const int center) {
   std::vector<std::vector<size_t>> ctrct_leg_idxs;
   if (i < center) {
-    if (i == 0) {
-      ctrct_leg_idxs = {{0}, {0}};
-    } else {
-      ctrct_leg_idxs = {{0, 1}, {0, 1}};
-    }
+    ctrct_leg_idxs = {{0, 1}, {0, 1}};
   } else if (i > center) {
-    if (i == mps.size() - 1) {
-      ctrct_leg_idxs = {{1}, {1}};
-    } else {
-      ctrct_leg_idxs = {{1, 2}, {1, 2}};
-    }
+    ctrct_leg_idxs = {{1, 2}, {1, 2}};
   }
 
   Tensor res;

--- a/tests/test_one_dim_tn/test_finite_mps/test_finite_mps_measu.cc
+++ b/tests/test_one_dim_tn/test_finite_mps/test_finite_mps_measu.cc
@@ -99,22 +99,22 @@ TEST_F(TestMpsMeasurement, TestMeasureOneSiteOp) {
   // Double case 1
   std::vector<GQTEN_Double> dres1;
   for (long i = 0; i < N; ++i) { dres1.push_back(stat_labs1[i]); }
-  DirectStateInitMps(dmps, stat_labs1, qn0);
+  DirectStateInitMps(dmps, stat_labs1);
   RunTestMeasureOneSiteOpCase(dmps, dntot, dres1);
   // Double case 2
   std::vector<GQTEN_Double> dres2;
   for (long i = 0; i < N; ++i) { dres2.push_back(stat_labs2[i]); }
-  DirectStateInitMps(dmps, stat_labs2, qn0);
+  DirectStateInitMps(dmps, stat_labs2);
   RunTestMeasureOneSiteOpCase(dmps, dntot, dres2);
   // Complex case 1
   std::vector<GQTEN_Complex> zres1;
   for (auto d : dres1) { zres1.push_back(d); }
-  DirectStateInitMps(zmps, stat_labs1, qn0);
+  DirectStateInitMps(zmps, stat_labs1);
   RunTestMeasureOneSiteOpCase(zmps, zntot, zres1);
   // Complex case 2
   std::vector<GQTEN_Complex> zres2;
   for (auto d : dres2) { zres2.push_back(d); }
-  DirectStateInitMps(zmps, stat_labs2, qn0);
+  DirectStateInitMps(zmps, stat_labs2);
   RunTestMeasureOneSiteOpCase(zmps, zntot, zres2);
 }
 
@@ -148,22 +148,22 @@ TEST_F(TestMpsMeasurement, TestMeasureTwoSiteOp) {
 
   // Double case 1
   std::vector<GQTEN_Double> dres1(sites_set.size(), 1.0);
-  DirectStateInitMps(dmps, stat_labs1, qn0);
+  DirectStateInitMps(dmps, stat_labs1);
   RunTestMeasureTwoSiteOpCase(dmps, {did, did}, did, sites_set, dres1);
   RunTestMeasureTwoSiteOpCase(dmps, {dntot, dntot}, did, sites_set, dres1);
   // Double case 2
-  DirectStateInitMps(dmps, stat_labs2, qn0);
+  DirectStateInitMps(dmps, stat_labs2);
   RunTestMeasureTwoSiteOpCase(dmps, {did, did}, did, sites_set, dres1);
   std::vector<GQTEN_Double> dres2 = {0, 0, 0, 0, 1, 0};
   RunTestMeasureTwoSiteOpCase(dmps, {dntot, dntot}, did, sites_set, dres2);
 
   // Complex case 1
   std::vector<GQTEN_Complex> zres1(sites_set.size(), 1.0);
-  DirectStateInitMps(zmps, stat_labs1, qn0);
+  DirectStateInitMps(zmps, stat_labs1);
   RunTestMeasureTwoSiteOpCase(zmps, {zid, zid}, zid, sites_set, zres1);
   RunTestMeasureTwoSiteOpCase(zmps, {zntot, zntot}, zid, sites_set, zres1);
   // Double case 2
-  DirectStateInitMps(zmps, stat_labs2, qn0);
+  DirectStateInitMps(zmps, stat_labs2);
   RunTestMeasureTwoSiteOpCase(zmps, {zid, zid}, zid, sites_set, zres1);
   std::vector<GQTEN_Complex> zres2 = {0, 0, 0, 0, 1, 0};
   RunTestMeasureTwoSiteOpCase(zmps, {zntot, zntot}, zid, sites_set, zres2);

--- a/tests/testdata/test-params.json
+++ b/tests/testdata/test-params.json
@@ -4,11 +4,12 @@
     "Double": 2.33,
     "Char": "c",
     "String": "string",
-    "Boolean": false 
+    "Boolean": false,
+    "DoubleVec": [0.1, 0.02, 0.003]
   },
 
   "Unused": {
-    "UnusedInt": 1, 
+    "UnusedInt": 1,
     "UnusedObj": {
       "key1": "val",
       "key2": 2.0


### PR DESCRIPTION
The updates include:
1. the first and last site mps/mpo tensors are modified as rank-3 tensors;
2. modifying the API of Lanczos;
3. single site update algorithm.